### PR TITLE
Adds trigger and wait flow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Run integration tests
         env:
           PREFECT_ORION_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
+          DBT_CLOUD_JOB_ID: ${{ secrets.DBT_CLOUD_JOB_ID }}
+          DBT_CLOUD_ACCOUNT_ID: ${{ secrets.DBT_CLOUD_ACCOUNT_ID }}
+          DBT_CLOUD_API_KEY: ${{ secrets.DBT_CLOUD_API_KEY }}
         run: |
           pytest tests -vv -m integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: Tests
 on: [pull_request]
 
 jobs:
-  run-tests:
-    name: Run Tests
+  run-unit-tests:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,9 +29,37 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade --upgrade-strategy eager -e ".[dev]"
 
-      - name: Run tests
+      - name: Run unit tests
         env:
           PREFECT_ORION_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         run: |
-          coverage run --branch -m pytest tests -vv
+          coverage run --branch -m pytest tests -vv -m "not integration"
           coverage report
+  run-integration-tests:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements*.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade --upgrade-strategy eager -e ".[dev]"
+
+      - name: Run integration tests
+        env:
+          PREFECT_ORION_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
+        run: |
+          pytest tests -vv -m integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `trigger_job_run` task - [#16](https://github.com/PrefectHQ/prefect-dbt/pull/16)
+- `trigger_dbt_cloud_job_run` task - [#16](https://github.com/PrefectHQ/prefect-dbt/pull/16)
+- `get_dbt_cloud_run_info` task - [#17](https://github.com/PrefectHQ/prefect-dbt/pull/17)
+- `trigger_dbt_cloud_job_run_and_wait_for_completion` flow - [#17](https://github.com/PrefectHQ/prefect-dbt/pull/17)
 
 ### Changed
 

--- a/prefect_dbt/cloud/clients.py
+++ b/prefect_dbt/cloud/clients.py
@@ -55,6 +55,23 @@ class DbtCloudAdministrativeClient:
 
         return response
 
+    async def get_run(self, run_id: int) -> Response:
+        """
+        Sends a request to the [get run endpoint](https://docs.getdbt.com/dbt-cloud/api-v2#tag/Runs/operation/getRunById)
+        to get details about a job run.
+
+        Args:
+            run_id: The ID of the run to get details for.
+
+        Returns:
+            The response from the dbt Cloud administrative API.
+        """  # noqa
+        response = await self._admin_client.get(f"/runs/{run_id}/")
+
+        response.raise_for_status()
+
+        return response
+
     async def __aenter__(self):
         if self._closed:
             raise RuntimeError(

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -290,7 +290,9 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
     seconds_waited_for_run_completion = 0
     while not max_wait_seconds or seconds_waited_for_run_completion <= max_wait_seconds:
         get_run_state = await get_dbt_cloud_run_info(
-            dbt_cloud_credentials=dbt_cloud_credentials, run_id=run_id
+            dbt_cloud_credentials=dbt_cloud_credentials,
+            run_id=run_id,
+            wait_for=[trigger_job_run_state],
         )
         run_data = await get_run_state.result()
         run_status_code = run_data.get("status")

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -53,7 +53,6 @@ class DbtCloudJobRunStatus(Enum):
     SUCCESS = 10
     FAILED = 20
     CANCELLED = 30
-    TERMINAL_STATUSES = (SUCCESS, FAILED, CANCELLED)
 
     @classmethod
     def is_terminal_status_code(cls, status_code: int) -> bool:
@@ -61,7 +60,7 @@ class DbtCloudJobRunStatus(Enum):
         Returns True if a status code is terminal for a job run.
         Return False otherwise.
         """
-        return status_code in cls.TERMINAL_STATUSES.value
+        return status_code in [cls.SUCCESS.value, cls.FAILED.value, cls.CANCELLED.value]
 
 
 @task(

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -6,10 +6,17 @@ from prefect import task
 
 from prefect_dbt.cloud.credentials import DbtCloudCredentials
 from prefect_dbt.cloud.models import TriggerJobRunOptions
+from prefect_dbt.cloud.utils import extract_user_message
 
 
 class JobRunTriggerFailed(Exception):
     """Raised when a dbt Cloud job trigger fails"""
+
+    pass
+
+
+class GetRunFailed(Exception):
+    """Raised when unable to retrieve dbt Cloud run"""
 
     pass
 
@@ -91,6 +98,45 @@ async def trigger_job_run(
         async with dbt_cloud_credentials.get_administrative_client() as client:
             response = await client.trigger_job_run(job_id=job_id, options=options)
     except HTTPStatusError as ex:
-        status = ex.response.json().get("status", {})
-        raise JobRunTriggerFailed(status.get("user_message")) from ex
+        raise JobRunTriggerFailed(extract_user_message(ex)) from ex
+    return response
+
+
+@task
+async def get_run(dbt_cloud_credentials: DbtCloudCredentials, run_id: int):
+    """
+    A task to retrieve information about a dbt Cloud job run.
+
+    Args:
+        dbt_cloud_credentials: Credentials for authenticating with dbt Cloud.
+        run_id: The ID of the job to trigger.
+
+    Returns:
+        The response from the dbt Cloud administrative API.
+
+    Example:
+        Get status of a dbt Cloud job run:
+        ```python
+        from prefect import flow
+
+        from prefect_dbt.cloud import DbtCloudCredentials
+        from prefect_dbt.cloud.jobs import get_run
+
+        @flow
+        def get_run_flow():
+            credentials = DbtCloudCredentials(api_key="my_api_key", account_id=123456789)
+
+            return get_run(
+                dbt_cloud_credentials=credentials,
+                run_id=42
+            )
+
+        get_run_flow()
+        ```
+    """  # noqa
+    try:
+        async with dbt_cloud_credentials.get_administrative_client() as client:
+            response = await client.get_run(run_id=run_id)
+    except HTTPStatusError as ex:
+        raise GetRunFailed(extract_user_message(ex)) from ex
     return response

--- a/prefect_dbt/cloud/utils.py
+++ b/prefect_dbt/cloud/utils.py
@@ -1,0 +1,21 @@
+"""Utility methods for common interactions with dbt Cloud API responses"""
+
+from typing import Optional
+
+from httpx import HTTPStatusError
+
+
+def extract_user_message(ex: HTTPStatusError) -> Optional[str]:
+    """
+    Extracts user message from a error response from the dbt Cloud administrative API.
+
+    Args:
+        ex: An HTTPStatusError raised by httpx
+
+    Returns:
+        user_message from dbt Cloud administrative API response or None if a
+        user_message cannot be extracted
+    """
+    response_payload = ex.response.json()
+    status = response_payload.get("status", {})
+    return status.get("user_message")

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,5 @@ show_missing = True
 
 [tool:pytest]
 asyncio_mode = auto
+markers = 
+    integration: marks tests as integration tests

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -7,8 +7,8 @@ from prefect import flow
 
 from prefect_dbt.cloud.credentials import DbtCloudCredentials
 from prefect_dbt.cloud.jobs import (
-    GetRunFailed,
-    JobRunTriggerFailed,
+    DbtCloudGetRunFailed,
+    DbtCloudJobRunTriggerFailed,
     get_run,
     trigger_job_run,
 )
@@ -29,7 +29,7 @@ class TestTriggerJobRun:
             job_id=1,
         )
         assert response.status_code == 200
-        assert response.json() == {"data": {"id": 10000}}
+        assert response.json() == {"id": 10000}
 
     @respx.mock(assert_all_called=True)
     async def test_trigger_job_within_flow(self, respx_mock: respx.MockRouter):
@@ -51,7 +51,7 @@ class TestTriggerJobRun:
         task_state = flow_state.result()
         result = task_state.result()
         assert result.status_code == 200
-        assert result.json() == {"data": {"id": 10000}}
+        assert result.json() == {"id": 10000}
         request_body = json.loads(respx_mock.calls.last.request.content.decode())
         assert "Triggered via Prefect in task run" in request_body["cause"]
 
@@ -97,7 +97,7 @@ class TestTriggerJobRun:
             ),
         )
         assert response.status_code == 200
-        assert response.json() == {"data": {"id": 10000}}
+        assert response.json() == {"id": 10000}
 
     @respx.mock(assert_all_called=True)
     async def test_trigger_nonexistent_job(self, respx_mock):
@@ -108,7 +108,7 @@ class TestTriggerJobRun:
         ).mock(
             return_value=Response(404, json={"status": {"user_message": "Not found!"}})
         )
-        with pytest.raises(JobRunTriggerFailed, match="Not found!"):
+        with pytest.raises(DbtCloudJobRunTriggerFailed, match="Not found!"):
             await trigger_job_run.fn(
                 dbt_cloud_credentials=DbtCloudCredentials(
                     api_key="my_api_key", account_id=123456789
@@ -133,7 +133,7 @@ class TestGetRun:
         )
 
         assert response.status_code == 200
-        assert response.json() == {"data": {"id": 10000}}
+        assert response.json() == {"id": 10000}
 
     @respx.mock(assert_all_called=True)
     async def test_get_nonexistent_run(self, respx_mock):
@@ -143,7 +143,7 @@ class TestGetRun:
         ).mock(
             return_value=Response(404, json={"status": {"user_message": "Not found!"}})
         )
-        with pytest.raises(GetRunFailed, match="Not found!"):
+        with pytest.raises(DbtCloudGetRunFailed, match="Not found!"):
             await get_run.fn(
                 dbt_cloud_credentials=DbtCloudCredentials(
                     api_key="my_api_key", account_id=123456789

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 from httpx import Response
@@ -289,3 +290,32 @@ class TestTriggerDbtCloudJobRunAndWaitForCompletion:
         )
         with pytest.raises(DbtCloudJobRunTimedOut):
             assert flow_state.result()
+
+
+@pytest.fixture
+def real_dbt_cloud_job_id():
+    return os.environ.get("DBT_CLOUD_JOB_ID")
+
+
+@pytest.fixture
+def real_dbt_cloud_api_key():
+    return os.environ.get("DBT_CLOUD_API_KEY")
+
+
+@pytest.fixture
+def real_dbt_cloud_account_id():
+    return os.environ.get("DBT_CLOUD_ACCOUNT_ID")
+
+
+@pytest.mark.integration
+async def test_run_real_dbt_cloud_job(
+    real_dbt_cloud_job_id, real_dbt_cloud_api_key, real_dbt_cloud_account_id
+):
+    flow_state = await trigger_dbt_cloud_job_run_and_wait_for_completion(
+        dbt_cloud_credentials=DbtCloudCredentials(
+            api_key=real_dbt_cloud_api_key, account_id=real_dbt_cloud_account_id
+        ),
+        job_id=real_dbt_cloud_job_id,
+        poll_frequency_seconds=1,
+    )
+    assert flow_state.result().get("status") == 10

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -9,8 +9,8 @@ from prefect_dbt.cloud.credentials import DbtCloudCredentials
 from prefect_dbt.cloud.jobs import (
     DbtCloudGetRunFailed,
     DbtCloudJobRunTriggerFailed,
-    get_run,
-    trigger_job_run,
+    get_dbt_cloud_run_info,
+    trigger_dbt_cloud_job_run,
 )
 from prefect_dbt.cloud.models import TriggerJobRunOptions
 
@@ -29,7 +29,7 @@ class TestTriggerJobRun:
 
         @flow
         async def test_flow():
-            return await trigger_job_run(
+            return await trigger_dbt_cloud_job_run(
                 dbt_cloud_credentials=DbtCloudCredentials(
                     api_key="my_api_key", account_id=123456789
                 ),
@@ -72,7 +72,7 @@ class TestTriggerJobRun:
 
         @flow
         async def test_flow():
-            return await trigger_job_run(
+            return await trigger_dbt_cloud_job_run(
                 dbt_cloud_credentials=DbtCloudCredentials(
                     api_key="my_api_key", account_id=123456789
                 ),
@@ -110,7 +110,7 @@ class TestTriggerJobRun:
 
         @flow
         async def test_flow():
-            await trigger_job_run(
+            await trigger_dbt_cloud_job_run(
                 dbt_cloud_credentials=DbtCloudCredentials(
                     api_key="my_api_key", account_id=123456789
                 ),
@@ -130,7 +130,7 @@ class TestGetRun:
             headers={"Authorization": "Bearer my_api_key"},
         ).mock(return_value=Response(200, json={"data": {"id": 10000}}))
 
-        response = await get_run.fn(
+        response = await get_dbt_cloud_run_info.fn(
             dbt_cloud_credentials=DbtCloudCredentials(
                 api_key="my_api_key", account_id=123456789
             ),
@@ -148,7 +148,7 @@ class TestGetRun:
             return_value=Response(404, json={"status": {"user_message": "Not found!"}})
         )
         with pytest.raises(DbtCloudGetRunFailed, match="Not found!"):
-            await get_run.fn(
+            await get_dbt_cloud_run_info.fn(
                 dbt_cloud_credentials=DbtCloudCredentials(
                     api_key="my_api_key", account_id=123456789
                 ),


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Adds a flow that can be used to trigger a dbt Cloud job run and wait for that run's completion. Makes use the of the previously created trigger task and a new task (`get_dbt_cloud_run_info`) to periodically check the run's status.

### Usage
The `trigger_dbt_cloud_job_run_and_wait_for_completion` flow can be run as a standalone flow:

```python
import asyncio

from prefect_dbt.cloud import DbtCloudCredentials
from prefect_dbt.cloud.jobs import trigger_dbt_cloud_job_run_and_wait_for_completion

asyncio.run(
    trigger_dbt_cloud_job_run_and_wait_for_completion(
        dbt_cloud_credentials=DbtCloudCredentials(
            api_key="my_api_key",
            account_id=123456789
        ),
        job_id=1
    )
)
```

Or run as a subflow:
```python
from prefect import flow

from prefect_dbt.cloud import DbtCloudCredentials
from prefect_dbt.cloud.jobs import trigger_dbt_cloud_job_run_and_wait_for_completion

@flow
def my_flow():
    ...
    run_result = trigger_dbt_cloud_job_run_and_wait_for_completion(
        dbt_cloud_credentials=DbtCloudCredentials(
            api_key="my_api_key",
            account_id=123456789
        ),
        job_id=1
    )
    ...
my_flow()
```


## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes #8 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
