### PR TITLE
Adds task for listing job run artifacts

### DIFF
--- a/docs/cloud/runs.md
+++ b/docs/cloud/runs.md
@@ -1,0 +1,1 @@
+::: prefect_dbt.cloud.runs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
     - Cloud:
       - Credentials: cloud/credentials.md
       - Jobs: cloud/jobs.md
+      - Runs: cloud/runs.md
       - Clients: cloud/clients.md
       - Models: cloud/models.md
 

--- a/prefect_dbt/cloud/clients.py
+++ b/prefect_dbt/cloud/clients.py
@@ -72,6 +72,34 @@ class DbtCloudAdministrativeClient:
 
         return response
 
+    async def list_run_artifacts(
+        self, run_id: int, step: Optional[int] = None
+    ) -> Response:
+        """
+        Sends a request to the [list run artifacts endpoint](https://docs.getdbt.com/dbt-cloud/api-v2#tag/Runs/operation/listArtifactsByRunId)
+        to fetch a list of artifact files generated for a completed run.
+
+        Args:
+            run_id: The ID of the run to list run artifacts for.
+            step: The index of the step in the run to query for artifacts. The
+                first step in the run has the index 1. If the step parameter is
+                omitted, then this method will return the artifacts compiled
+                for the last step in the run.
+
+        Returns:
+            The response from the dbt Cloud administrative API.
+        """  # noqa
+        params = dict()
+        if step:
+            params["step"] = step
+        response = await self._admin_client.get(
+            f"/runs/{run_id}/artifacts/", params=params
+        )
+
+        response.raise_for_status()
+
+        return response
+
     async def __aenter__(self):
         if self._closed:
             raise RuntimeError(

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -1,4 +1,4 @@
-"""Module containing tasks and flows for interacting with dbt Cloud"""
+"""Module containing tasks and flows for interacting with dbt Cloud jobs"""
 import asyncio
 from enum import Enum
 from typing import Dict, Optional
@@ -8,17 +8,16 @@ from prefect import flow, get_run_logger, task
 
 from prefect_dbt.cloud.credentials import DbtCloudCredentials
 from prefect_dbt.cloud.models import TriggerJobRunOptions
+from prefect_dbt.cloud.runs import (
+    DbtCloudListRunArtifactsFailed,
+    get_dbt_cloud_run_info,
+    list_dbt_cloud_run_artifacts,
+)
 from prefect_dbt.cloud.utils import extract_user_message
 
 
 class DbtCloudJobRunTriggerFailed(Exception):
     """Raised when a dbt Cloud job trigger fails"""
-
-    pass
-
-
-class DbtCloudGetRunFailed(Exception):
-    """Raised when unable to retrieve dbt Cloud run"""
 
     pass
 
@@ -165,54 +164,6 @@ async def trigger_dbt_cloud_job_run(
     return run_data
 
 
-@task(
-    name="Get dbt Cloud job run details",
-    description="Retrieves details of a dbt Cloud job run "
-    "for the run with the given run_id.",
-    retries=3,
-    retry_delay_seconds=10,
-)
-async def get_dbt_cloud_run_info(
-    dbt_cloud_credentials: DbtCloudCredentials, run_id: int
-) -> Dict:
-    """
-    A task to retrieve information about a dbt Cloud job run.
-
-    Args:
-        dbt_cloud_credentials: Credentials for authenticating with dbt Cloud.
-        run_id: The ID of the job to trigger.
-
-    Returns:
-        The run data returned by the dbt Cloud administrative API.
-
-    Example:
-        Get status of a dbt Cloud job run:
-        ```python
-        from prefect import flow
-
-        from prefect_dbt.cloud import DbtCloudCredentials
-        from prefect_dbt.cloud.jobs import get_run
-
-        @flow
-        def get_run_flow():
-            credentials = DbtCloudCredentials(api_key="my_api_key", account_id=123456789)
-
-            return get_run(
-                dbt_cloud_credentials=credentials,
-                run_id=42
-            )
-
-        get_run_flow()
-        ```
-    """  # noqa
-    try:
-        async with dbt_cloud_credentials.get_administrative_client() as client:
-            response = await client.get_run(run_id=run_id)
-    except HTTPStatusError as ex:
-        raise DbtCloudGetRunFailed(extract_user_message(ex)) from ex
-    return response.json()["data"]
-
-
 @flow
 async def trigger_dbt_cloud_job_run_and_wait_for_completion(
     dbt_cloud_credentials: DbtCloudCredentials,
@@ -311,6 +262,8 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
         ```
 
     """  # noqa
+    logger = get_run_logger()
+
     trigger_job_run_future = await trigger_dbt_cloud_job_run(
         dbt_cloud_credentials=dbt_cloud_credentials,
         job_id=job_id,
@@ -330,18 +283,37 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
         run_status_code = run_data.get("status")
 
         if run_status_code == DbtCloudJobRunStatus.SUCCESS.value:
+            try:
+                list_run_artifacts_state = await list_dbt_cloud_run_artifacts(
+                    dbt_cloud_credentials=dbt_cloud_credentials, run_id=run_id
+                )
+                run_data["artifact_paths"] = await list_run_artifacts_state.result()
+                return run_data
+            except DbtCloudListRunArtifactsFailed as ex:
+                logger.warn(
+                    "Unable to retrieve artifacts for job run with ID %s. Reason: %s",
+                    run_id,
+                    ex,
+                )
+
             return run_data
         elif run_status_code == DbtCloudJobRunStatus.FAILED.value:
             raise DbtCloudJobRunFailed(f"Triggered job run with ID: {run_id} failed.")
         elif run_status_code == DbtCloudJobRunStatus.CANCELLED.value:
             raise DbtCloudJobRunCancelled(
-                f"Triggered job run with ID: {run_id} was cancelled."
+                f"Triggered job run with ID {run_id} was cancelled."
             )
 
+        logger.info(
+            "dbt Cloud job run with ID %i has status %s. Waiting for %i seconds.",
+            run_id,
+            DbtCloudJobRunStatus(run_status_code).name,
+            poll_frequency_seconds,
+        )
         await asyncio.sleep(poll_frequency_seconds)
         seconds_waited_for_run_completion += poll_frequency_seconds
 
     raise DbtCloudJobRunTimedOut(
         f"Max wait time of {max_wait_seconds} seconds exceeded while waiting "
-        "for job run with ID: {run_id}"
+        "for job run with ID {run_id}"
     )

--- a/prefect_dbt/cloud/runs.py
+++ b/prefect_dbt/cloud/runs.py
@@ -1,0 +1,119 @@
+"""Module containing tasks and flows for interacting with dbt Cloud job runs"""
+from typing import Dict, List, Optional
+
+from httpx import HTTPStatusError
+from prefect import task
+
+from prefect_dbt.cloud.credentials import DbtCloudCredentials
+from prefect_dbt.cloud.utils import extract_user_message
+
+
+class DbtCloudGetRunFailed(Exception):
+    """Raised when unable to retrieve dbt Cloud run"""
+
+    pass
+
+
+class DbtCloudListRunArtifactsFailed(Exception):
+    """Raised when unable to list dbt Cloud run artifacts"""
+
+    pass
+
+
+@task(
+    name="Get dbt Cloud job run details",
+    description="Retrieves details of a dbt Cloud job run "
+    "for the run with the given run_id.",
+    retries=3,
+    retry_delay_seconds=10,
+)
+async def get_dbt_cloud_run_info(
+    dbt_cloud_credentials: DbtCloudCredentials, run_id: int
+) -> Dict:
+    """
+    A task to retrieve information about a dbt Cloud job run.
+
+    Args:
+        dbt_cloud_credentials: Credentials for authenticating with dbt Cloud.
+        run_id: The ID of the job to trigger.
+
+    Returns:
+        The run data returned by the dbt Cloud administrative API.
+
+    Example:
+        Get status of a dbt Cloud job run:
+        ```python
+        from prefect import flow
+
+        from prefect_dbt.cloud import DbtCloudCredentials
+        from prefect_dbt.cloud.jobs import get_run
+
+        @flow
+        def get_run_flow():
+            credentials = DbtCloudCredentials(api_key="my_api_key", account_id=123456789)
+
+            return get_run(
+                dbt_cloud_credentials=credentials,
+                run_id=42
+            )
+
+        get_run_flow()
+        ```
+    """  # noqa
+    try:
+        async with dbt_cloud_credentials.get_administrative_client() as client:
+            response = await client.get_run(run_id=run_id)
+    except HTTPStatusError as ex:
+        raise DbtCloudGetRunFailed(extract_user_message(ex)) from ex
+    return response.json()["data"]
+
+
+@task(
+    name="List dbt Cloud job artifacts",
+    description="Fetches a list of artifact files generated for a completed run.",
+    retries=3,
+    retry_delay_seconds=10,
+)
+async def list_dbt_cloud_run_artifacts(
+    dbt_cloud_credentials: DbtCloudCredentials, run_id: int, step: Optional[int] = None
+) -> List[str]:
+    """
+    A task to list the artifact files generated for a completed run.
+
+    Args:
+        dbt_cloud_credentials: Credentials for authenticating with dbt Cloud.
+        run_id: The ID of the run to list run artifacts for.
+        step: The index of the step in the run to query for artifacts. The
+            first step in the run has the index 1. If the step parameter is
+            omitted, then this method will return the artifacts compiled
+            for the last step in the run.
+
+    Returns:
+        A list of paths to artifact files that can be used to retrieve the generated artifacts.
+
+    Example:
+        List artifacts of a dbt Cloud job run:
+        ```python
+        from prefect import flow
+
+        from prefect_dbt.cloud import DbtCloudCredentials
+        from prefect_dbt.cloud.jobs import list_dbt_cloud_run_artifacts
+
+        @flow
+        def get_run_flow():
+            credentials = DbtCloudCredentials(api_key="my_api_key", account_id=123456789)
+
+            return list_dbt_cloud_run_artifacts(
+                dbt_cloud_credentials=credentials,
+                run_id=42
+            )
+
+        get_run_flow()
+        ```
+    """  # noqa
+    try:
+        async with dbt_cloud_credentials.get_administrative_client() as client:
+            response = await client.list_run_artifacts(run_id=run_id, step=step)
+    except HTTPStatusError as ex:
+        raise DbtCloudListRunArtifactsFailed(extract_user_message(ex)) from ex
+    return response.json()["data"]

--- a/tests/cloud/test_runs.py
+++ b/tests/cloud/test_runs.py
@@ -1,0 +1,81 @@
+import pytest
+from httpx import Response
+
+from prefect_dbt.cloud.runs import (
+    DbtCloudGetRunFailed,
+    DbtCloudListRunArtifactsFailed,
+    get_dbt_cloud_run_info,
+    list_dbt_cloud_run_artifacts,
+)
+
+
+class TestGetDbtCloudRunInfo:
+    async def test_get_dbt_cloud_run_info(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/12/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": {"id": 10000}}))
+
+        response = await get_dbt_cloud_run_info.fn(
+            dbt_cloud_credentials=dbt_cloud_credentials,
+            run_id=12,
+        )
+
+        assert response == {"id": 10000}
+
+    async def test_get_nonexistent_run(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/12/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(
+            return_value=Response(404, json={"status": {"user_message": "Not found!"}})
+        )
+        with pytest.raises(DbtCloudGetRunFailed, match="Not found!"):
+            await get_dbt_cloud_run_info.fn(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                run_id=12,
+            )
+
+
+class TestDbtCloudListRunArtifacts:
+    async def test_list_artifacts_success(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/12/artifacts/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": ["manifest.json"]}))
+
+        response = await list_dbt_cloud_run_artifacts.fn(
+            dbt_cloud_credentials=dbt_cloud_credentials,
+            run_id=12,
+        )
+
+        assert response == ["manifest.json"]
+
+    async def test_list_artifacts_with_step(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/12/artifacts/?step=1",  # noqa
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": ["manifest.json"]}))
+
+        response = await list_dbt_cloud_run_artifacts.fn(
+            dbt_cloud_credentials=dbt_cloud_credentials, run_id=12, step=1
+        )
+
+        assert response == ["manifest.json"]
+
+    async def test_list_artifacts_failure(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/12/artifacts/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(
+            return_value=Response(
+                500, json={"status": {"user_message": "This is what went wrong"}}
+            )
+        )
+        with pytest.raises(
+            DbtCloudListRunArtifactsFailed, match="This is what went wrong"
+        ):
+            await list_dbt_cloud_run_artifacts.fn(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                run_id=12,
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from prefect_dbt.cloud.credentials import DbtCloudCredentials
+
+
+@pytest.fixture
+def dbt_cloud_credentials():
+    return DbtCloudCredentials(api_key="my_api_key", account_id=123456789)


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Adds `list_dbt_cloud_run_artifacts` to list artifacts from a dbt Cloud job run. This task has been incorporated in the `trigger_dbt_cloud_job_run_and_wait_for_completion` flow so that artifact paths are returned once a job run has completed. Also creates a new `runs` module to mirror the organization of the dbt Cloud administrative API documentation.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
