### PR TITLE
Generic endpoint task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `trigger_dbt_cloud_job_run_and_wait_for_completion` flow - [#17](https://github.com/PrefectHQ/prefect-dbt/pull/17)
 - `list_dbt_cloud_run_artifacts` task - [#23](https://github.com/PrefectHQ/prefect-dbt/pull/23)
 - `get_dbt_cloud_run_artifact` task - [#23](https://github.com/PrefectHQ/prefect-dbt/pull/23)
+- `call_dbt_cloud_administrative_api_endpoint` task - [#25](https://github.com/PrefectHQ/prefect-dbt/pull/25)
 
 ### Changed
 

--- a/docs/cloud/utils.md
+++ b/docs/cloud/utils.md
@@ -1,0 +1,1 @@
+::: prefect_dbt.cloud.utils

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,4 +42,5 @@ nav:
       - Runs: cloud/runs.md
       - Clients: cloud/clients.md
       - Models: cloud/models.md
+      - Utils: cloud/utils.md
 

--- a/prefect_dbt/cloud/clients.py
+++ b/prefect_dbt/cloud/clients.py
@@ -1,5 +1,5 @@
 """Module containing clients for interacting with the dbt Cloud API"""
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import prefect
 from httpx import AsyncClient, Response
@@ -27,6 +27,26 @@ class DbtCloudAdministrativeClient:
                 "user-agent": f"prefect-{prefect.__version__}",
             },
             base_url=f"https://{domain}/api/v2/accounts/{account_id}",
+        )
+
+    async def call_endpoint(
+        self, http_method: str, path: str, params: Dict[str, Any], json: Dict[str, Any]
+    ) -> Response:
+        """
+        Call an endpoint in the dbt Cloud API.
+
+        Args:
+            path: The partial path for the request (e.g. /projects/). Will be appended
+                onto the base URL as determined by the client configuration.
+            http_method: HTTP method to call on the endpoint.
+            params: Query parameters to include in the request.
+            json: JSON serializable body to send in the request.
+
+        Returns:
+            The response from the dbt Cloud administrative API.
+        """
+        return await self._admin_client.request(
+            method=http_method, url=path, params=params, json=json
         )
 
     async def trigger_job_run(

--- a/prefect_dbt/cloud/clients.py
+++ b/prefect_dbt/cloud/clients.py
@@ -74,14 +74,11 @@ class DbtCloudAdministrativeClient:
         if options is None:
             options = TriggerJobRunOptions()
 
-        response = await self._admin_client.post(
-            url=f"/jobs/{job_id}/run/",
+        return await self.call_endpoint(
+            path=f"/jobs/{job_id}/run/",
+            http_method="POST",
             json=options.dict(exclude_none=True),
         )
-
-        response.raise_for_status()
-
-        return response
 
     async def get_run(self, run_id: int) -> Response:
         """
@@ -94,11 +91,7 @@ class DbtCloudAdministrativeClient:
         Returns:
             The response from the dbt Cloud administrative API.
         """  # noqa
-        response = await self._admin_client.get(f"/runs/{run_id}/")
-
-        response.raise_for_status()
-
-        return response
+        return await self.call_endpoint(path=f"/runs/{run_id}/", http_method="GET")
 
     async def list_run_artifacts(
         self, run_id: int, step: Optional[int] = None
@@ -118,13 +111,9 @@ class DbtCloudAdministrativeClient:
             The response from the dbt Cloud administrative API.
         """  # noqa
         params = {"step": step} if step else None
-        response = await self._admin_client.get(
-            f"/runs/{run_id}/artifacts/", params=params
+        return await self.call_endpoint(
+            path=f"/runs/{run_id}/artifacts/", http_method="GET", params=params
         )
-
-        response.raise_for_status()
-
-        return response
 
     async def get_run_artifact(
         self, run_id: int, path: str, step: Optional[int] = None
@@ -146,13 +135,9 @@ class DbtCloudAdministrativeClient:
             The response from the dbt Cloud administrative API.
         """  # noqa
         params = {"step": step} if step else None
-        response = await self._admin_client.get(
-            f"/runs/{run_id}/artifacts/{path}", params=params
+        return await self.call_endpoint(
+            path=f"/runs/{run_id}/artifacts/{path}", http_method="GET", params=params
         )
-
-        response.raise_for_status()
-
-        return response
 
     async def __aenter__(self):
         if self._closed:

--- a/prefect_dbt/cloud/clients.py
+++ b/prefect_dbt/cloud/clients.py
@@ -30,7 +30,11 @@ class DbtCloudAdministrativeClient:
         )
 
     async def call_endpoint(
-        self, http_method: str, path: str, params: Dict[str, Any], json: Dict[str, Any]
+        self,
+        http_method: str,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
     ) -> Response:
         """
         Call an endpoint in the dbt Cloud API.
@@ -45,9 +49,13 @@ class DbtCloudAdministrativeClient:
         Returns:
             The response from the dbt Cloud administrative API.
         """
-        return await self._admin_client.request(
+        response = await self._admin_client.request(
             method=http_method, url=path, params=params, json=json
         )
+
+        response.raise_for_status()
+
+        return response
 
     async def trigger_job_run(
         self, job_id: int, options: Optional[TriggerJobRunOptions] = None

--- a/prefect_dbt/cloud/credentials.py
+++ b/prefect_dbt/cloud/credentials.py
@@ -7,12 +7,13 @@ from prefect_dbt.cloud.clients import DbtCloudAdministrativeClient
 
 class DbtCloudCredentials(Block):
     """
-    Credentials class for credential use across dbt Cloud tasks and flows.
+    Credentials block for credential use across dbt Cloud tasks and flows.
 
     Args:
-        api_key: API key to authenticate with the dbt Cloud administrative API.
-        account_id: ID of dbt Cloud account with which to interact.
-        domain: Domain at which the dbt Cloud API is hosted.
+        api_key (SecretStr): API key to authenticate with the dbt Cloud
+            administrative API.
+        account_id (int): ID of dbt Cloud account with which to interact.
+        domain (Optional[str]): Domain at which the dbt Cloud API is hosted.
 
     Examples:
         Use DbtCloudCredentials instance to trigger a job run:

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -164,7 +164,11 @@ async def trigger_dbt_cloud_job_run(
     return run_data
 
 
-@flow
+@flow(
+    name="Trigger dbt Cloud job run and wait for completions",
+    description="Triggers a dbt Cloud job run and waits for the"
+    "triggered run to complete.",
+)
 async def trigger_dbt_cloud_job_run_and_wait_for_completion(
     dbt_cloud_credentials: DbtCloudCredentials,
     job_id: int,

--- a/prefect_dbt/cloud/utils.py
+++ b/prefect_dbt/cloud/utils.py
@@ -78,7 +78,7 @@ async def call_dbt_cloud_administrative_api_endpoint(
         response = await client.call_endpoint(
             http_method=http_method, path=path, params=params, json=json
         )
-        try:
-            return response.json()
-        except JSONDecodeError:
-            return response.text
+    try:
+        return response.json()
+    except JSONDecodeError:
+        return response.text

--- a/prefect_dbt/cloud/utils.py
+++ b/prefect_dbt/cloud/utils.py
@@ -54,7 +54,7 @@ async def call_dbt_cloud_administrative_api_endpoint(
             `json.loads` with the body as the input will be returned. Otherwise, the
             body will be returned directly.
 
-    Example:
+    Examples:
         List projects for an account:
         ```python
         from prefect import flow
@@ -69,7 +69,42 @@ async def call_dbt_cloud_administrative_api_endpoint(
             future = call_dbt_cloud_administrative_api_endpoint(
                 dbt_cloud_credentials=credentials,
                 path="/projects/",
-                http_method="get",
+                http_method="GET",
+            )
+            return future.result()["data"]
+        ```
+
+        Create a new job:
+        ```python
+        from prefect import flow
+
+        from prefect_dbt.cloud import DbtCloudCredentials
+        from prefect_dbt.cloud.utils import call_dbt_cloud_administrative_api_endpoint
+
+
+        @flow
+        def create_job_flow():
+            credentials = DbtCloudCredentials(api_key="my_api_key", account_id=123456789)
+
+            future = call_dbt_cloud_administrative_api_endpoint(
+                dbt_cloud_credentials=credentials,
+                path="/jobs/",
+                http_method="POST",
+                json={
+                    "account_id": 123456789,
+                    "project_id": 100,
+                    "environment_id": 10,
+                    "name": "Nightly run",
+                    "dbt_version": "0.17.1",
+                    "triggers": {"github_webhook": True, "schedule": True},
+                    "execute_steps": ["dbt run", "dbt test", "dbt source snapshot-freshness"],
+                    "settings": {"threads": 4, "target_name": "prod"},
+                    "state": 1,
+                    "schedule": {
+                        "date": {"type": "every_day"},
+                        "time": {"type": "every_hour", "interval": 1},
+                    },
+                },
             )
             return future.result()["data"]
         ```

--- a/prefect_dbt/cloud/utils.py
+++ b/prefect_dbt/cloud/utils.py
@@ -34,8 +34,8 @@ async def call_dbt_cloud_administrative_api_endpoint(
     dbt_cloud_credentials: DbtCloudCredentials,
     path: str,
     http_method: str,
-    params: Dict[str, Any],
-    json: Dict[str, Any],
+    params: Optional[Dict[str, Any]] = None,
+    json: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """
     Task that calls a specified endpoint in the dbt Cloud administrative API. Use this
@@ -53,7 +53,27 @@ async def call_dbt_cloud_administrative_api_endpoint(
         The body of the response. If the body is JSON serializable, then the result of
             `json.loads` with the body as the input will be returned. Otherwise, the
             body will be returned directly.
-    """
+
+    Example:
+        List projects for an account:
+        ```python
+        from prefect import flow
+
+        from prefect_dbt.cloud import DbtCloudCredentials
+        from prefect_dbt.cloud.utils import call_dbt_cloud_administrative_api_endpoint
+
+        @flow
+        def get_projects_flow():
+            credentials = DbtCloudCredentials(api_key="my_api_key", account_id=123456789)
+
+            future = call_dbt_cloud_administrative_api_endpoint(
+                dbt_cloud_credentials=credentials,
+                path="/projects/",
+                http_method="get",
+            )
+            return future.result()["data"]
+        ```
+    """  # noqa
     async with dbt_cloud_credentials.get_administrative_client() as client:
         response = await client.call_endpoint(
             http_method=http_method, path=path, params=params, json=json

--- a/tests/cloud/test_utils.py
+++ b/tests/cloud/test_utils.py
@@ -1,0 +1,68 @@
+import pytest
+from httpx import HTTPStatusError, Response
+
+from prefect_dbt.cloud.utils import call_dbt_cloud_administrative_api_endpoint
+
+
+class TestCallDbtCloudAdministrativeApiEndpoint:
+    async def test_endpoint_returns_json(self, dbt_cloud_credentials, respx_mock):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/projects/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(
+            return_value=Response(
+                200,
+                json={
+                    "status": {
+                        "code": 200,
+                        "is_success": True,
+                        "user_message": "Success!",
+                        "developer_message": "",
+                    },
+                    "data": [],
+                },
+            )
+        )
+
+        result = await call_dbt_cloud_administrative_api_endpoint.fn(
+            dbt_cloud_credentials=dbt_cloud_credentials,
+            path="/projects/",
+            http_method="GET",
+        )
+
+        assert result == {
+            "status": {
+                "code": 200,
+                "is_success": True,
+                "user_message": "Success!",
+                "developer_message": "",
+            },
+            "data": [],
+        }
+
+    async def test_endpoint_returns_text(self, dbt_cloud_credentials, respx_mock):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/12/artifacts/compiled/dbt_artifacts/models/dim_dbt__current_models.sql",  # noqa
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, text="Hi! I'm some SQL!"))
+
+        result = await call_dbt_cloud_administrative_api_endpoint.fn(
+            dbt_cloud_credentials=dbt_cloud_credentials,
+            path="/runs/12/artifacts/compiled/dbt_artifacts/models/dim_dbt__current_models.sql",  # noqa
+            http_method="GET",
+        )
+
+        assert result == "Hi! I'm some SQL!"
+
+    async def test_failure(self, dbt_cloud_credentials, respx_mock):
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/projects/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(500))
+
+        with pytest.raises(HTTPStatusError):
+            await call_dbt_cloud_administrative_api_endpoint.fn(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                path="/projects/",
+                http_method="GET",
+            )


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Adds `call_dbt_cloud_administrative_api_endpoint` task which allows users a simple interface to call dbt Cloud endpoints that custom tasks have not yet been created for.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes #10 

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
