### PR TITLE
Move block examples to docstring

### DIFF
--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -53,7 +53,7 @@ class DbtConfigs(Block, abc.ABC):
         return self._populate_configs_json({}, self.dict())
 
 
-class TargetConfigs(DbtConfigs):
+class TargetConfigs(Block):
     """
     Target configs contain credentials and
     settings, specific to the warehouse you're connecting to.
@@ -67,16 +67,18 @@ class TargetConfigs(DbtConfigs):
             in BigQuery, a schema is actually a dataset.
         threads: The number of threads representing the max number
             of paths through the graph dbt may work on at once.
+
+    Examples:
+        Load stored TargetConfigs:
+        ```python
+        from prefect_dbt.cli.configs import TargetConfigs
+
+        dbt_cli_target_configs = TargetConfigs.load("BLOCK_NAME")
+        ```
     """
 
     _block_type_name = "dbt CLI Target Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cli.configs import TargetConfigs
-        
-        dbt_cli_target_configs = TargetConfigs.load("BLOCK_NAME")
-    ```"""  # noqa
 
     type: str
     schema_: str = Field(alias="schema")
@@ -112,16 +114,18 @@ class GlobalConfigs(DbtConfigs):
             of the static parser.
         static_parser: Whether to use the [static parser](
             https://docs.getdbt.com/reference/parsing#static-parser).
+
+    Examples:
+        Load stored GlobalConfigs:
+        ```python
+        from prefect_dbt.cli.configs import GlobalConfigs
+
+        dbt_cli_global_configs = GlobalConfigs.load("BLOCK_NAME")
+        ```
     """
 
     _block_type_name = "dbt CLI Global Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cli.configs import GlobalConfigs
-        
-        dbt_cli_global_configs = GlobalConfigs.load("BLOCK_NAME")
-    ```"""  # noqa
 
     send_anonymous_usage_stats: Optional[bool] = None
     use_colors: Optional[bool] = None

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -53,7 +53,7 @@ class DbtConfigs(Block, abc.ABC):
         return self._populate_configs_json({}, self.dict())
 
 
-class TargetConfigs(Block):
+class TargetConfigs(DbtConfigs):
     """
     Target configs contain credentials and
     settings, specific to the warehouse you're connecting to.

--- a/prefect_dbt/cli/configs/bigquery.py
+++ b/prefect_dbt/cli/configs/bigquery.py
@@ -28,6 +28,13 @@ class BigQueryTargetConfigs(TargetConfigs):
             e.g. schema, an error will be raised.
 
     Examples:
+        Load stored BigQueryTargetConfigs:
+        ```python
+        from prefect_dbt.cli.configs import BigQueryTargetConfigs
+
+        bigquery_target_configs = BigQueryTargetConfigs.load("BLOCK_NAME")
+        ```
+
         Instantiate BigQueryTargetConfigs with service account file.
         ```python
         from prefect_dbt.cli.configs import BigQueryTargetConfigs
@@ -71,12 +78,6 @@ class BigQueryTargetConfigs(TargetConfigs):
 
     _block_type_name = "dbt CLI BigQuery Target Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cli.configs import BigQueryTargetConfigs
-        
-        dbt_cli_target_configs = BigQueryTargetConfigs.load("BLOCK_NAME")
-    ```"""  # noqa
     _description = "dbt CLI target configs containing credentials and settings, specific to BigQuery."  # noqa
 
     type: Literal["gcp"] = "gcp"

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -28,6 +28,13 @@ class PostgresTargetConfigs(TargetConfigs):
             e.g. schema, an error will be raised.
 
     Examples:
+        Load stored PostgresTargetConfigs:
+        ```python
+        from prefect_dbt.cli.configs import PostgresTargetConfigs
+
+        postgres_target_configs = PostgresTargetConfigs.load("BLOCK_NAME")
+        ```
+
         Instantiate PostgresTargetConfigs with DatabaseCredentials.
         ```python
         from prefect_dbt.cli.configs import PostgresTargetConfigs
@@ -47,12 +54,6 @@ class PostgresTargetConfigs(TargetConfigs):
 
     _block_type_name = "dbt CLI Postgres Target Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cli.configs import PostgresTargetConfigs
-        
-        dbt_cli_target_configs = PostgresTargetConfigs.load("BLOCK_NAME")
-    ```"""  # noqa
     _description = "dbt CLI target configs containing credentials and settings specific to Postgres."  # noqa
 
     type: Literal["postgres"] = "postgres"

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -34,7 +34,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
         ```python
         from prefect_dbt.cli.configs import SnowflakeTargetConfigs
 
-        dbt_cli_snowflake_target_configs = SnowflakeTargetConfigs.load("BLOCK_NAME")
+        snowflake_target_configs = SnowflakeTargetConfigs.load("BLOCK_NAME")
         ```
 
         Instantiate SnowflakeTargetConfigs.

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -30,6 +30,13 @@ class SnowflakeTargetConfigs(TargetConfigs):
             e.g. schema, an error will be raised.
 
     Examples:
+        Load stored SnowflakeTargetConfigs:
+        ```python
+        from prefect_dbt.cli.configs import SnowflakeTargetConfigs
+
+        dbt_cli_snowflake_target_configs = SnowflakeTargetConfigs.load("BLOCK_NAME")
+        ```
+
         Instantiate SnowflakeTargetConfigs.
         ```python
         from prefect_dbt.cli.configs import SnowflakeTargetConfigs
@@ -52,12 +59,6 @@ class SnowflakeTargetConfigs(TargetConfigs):
 
     _block_type_name = "dbt CLI Snowflake Target Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cli.configs import SnowflakeTargetConfigs
-        
-        dbt_cli_snowflake_target_configs = SnowflakeTargetConfigs.load("BLOCK_NAME")
-    ```"""  # noqa
 
     type: Literal["snowflake"] = "snowflake"
     schema_: Optional[str] = Field(default=None, alias="schema")

--- a/prefect_dbt/cli/credentials.py
+++ b/prefect_dbt/cli/credentials.py
@@ -29,7 +29,7 @@ class DbtCliProfile(Block):
         Load stored dbt CLI profile:
         ```python
         from prefect_dbt.cli import DbtCliProfile
-        dbt_cli_profile = DbtCliProfile.load("MY_BLOCK").get_profile()
+        dbt_cli_profile = DbtCliProfile.load("BLOCK_NAME").get_profile()
         ```
 
         Get a dbt Snowflake profile from DbtCliProfile by using SnowflakeTargetConfigs:

--- a/prefect_dbt/cli/credentials.py
+++ b/prefect_dbt/cli/credentials.py
@@ -26,6 +26,12 @@ class DbtCliProfile(Block):
             https://docs.getdbt.com/reference/global-configs).
 
     Examples:
+        Load stored dbt CLI profile:
+        ```python
+        from prefect_dbt.cli import DbtCliProfile
+        dbt_cli_profile = DbtCliProfile.load("MY_BLOCK").get_profile()
+        ```
+
         Get a dbt Snowflake profile from DbtCliProfile by using SnowflakeTargetConfigs:
         ```python
         from prefect_dbt.cli import DbtCliProfile
@@ -77,22 +83,10 @@ class DbtCliProfile(Block):
         )
         profile = dbt_cli_profile.get_profile()
         ```
-
-        Load saved dbt CLI profile:
-        ```python
-        from prefect_dbt.cli import DbtCliProfile
-        profile = DbtCliProfile.load("my-dbt-credentials").get_profile()
-        ```
     """
 
     _block_type_name = "dbt CLI Profile"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cli import DbtCliProfile
-
-        dbt_cli_profile = DbtCliProfile.load("BLOCK_NAME")
-    ```"""  # noqa
 
     name: str
     target: str

--- a/prefect_dbt/cloud/credentials.py
+++ b/prefect_dbt/cloud/credentials.py
@@ -18,6 +18,13 @@ class DbtCloudCredentials(Block):
         domain (Optional[str]): Domain at which the dbt Cloud API is hosted.
 
     Examples:
+        Load stored dbt Cloud credentials:
+        ```python
+        from prefect_dbt.cloud import DbtCloudCredentials
+
+        dbt_cloud_credentials = DbtCloudCredentials.load("BLOCK_NAME")
+        ```
+
         Use DbtCloudCredentials instance to trigger a job run:
         ```python
         from prefect_dbt.cloud import DbtCloudCredentials
@@ -39,9 +46,7 @@ class DbtCloudCredentials(Block):
         @flow
         def trigger_dbt_cloud_job_run_flow():
             credentials = DbtCloudCredentials.load("my-dbt-credentials")
-
             trigger_dbt_cloud_job_run(dbt_cloud_credentials=credentials, job_id=1)
-
 
         trigger_dbt_cloud_job_run_flow()
         ```
@@ -49,12 +54,6 @@ class DbtCloudCredentials(Block):
 
     _block_type_name = "dbt Cloud Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
-    _code_example = """/
-    ```python
-        from prefect_dbt.cloud import DbtCloudCredentials
-
-        dbt_cloud_credentials = DbtCloudCredentials.load("BLOCK_NAME")
-    ```"""
 
     api_key: SecretStr
     account_id: int


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Moves examples into docstrings for safer parsing in UI; works even if there are multiple examples in the docstring, as long as it's the first one
![image](https://user-images.githubusercontent.com/15331990/181655344-f8c9fdab-40da-404f-9e5f-33728d1d8b7f.png)

Fixes:
https://github.com/PrefectHQ/prefect-dbt/issues/38

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
