### PR TITLE
Removes duplicate theme key in mkdocs.yaml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,11 +16,6 @@ theme:
     code: Source Code Pro
 extra_css:
     - stylesheets/extra.css
-theme:
-  name: material
-  palette:
-    primary: blue
-    accent: blue
 markdown_extensions:
     - admonition
     - attr_list


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
The duplicate theme prevents the correct logos from showing in the docs.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
