### PR TITLE
Prepare for new release of snowflake which does not have connect_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,47 @@ def trigger_dbt_cli_command_flow() -> str:
 trigger_dbt_cli_command_flow()
 ```
 
+### Execute a dbt CLI command without a pre-populated profiles.yml
+```python
+from prefect import flow
+from prefect_snowflake.credentials import SnowflakeCredentials
+from prefect_snowflake.database import SnowflakeConnector
+
+from prefect_dbt.cli.credentials import DbtCliProfile
+from prefect_dbt.cli.commands import trigger_dbt_cli_command
+from prefect_dbt.cli.configs import SnowflakeTargetConfigs
+
+@flow
+def trigger_dbt_cli_command_flow():
+    connector = SnowflakeConnector(
+        schema="public",
+        database="database",
+        warehouse="warehouse",
+        credentials=SnowflakeCredentials(
+            user="user",
+            password="password",
+            account="account.region.aws",
+            role="role",
+        ),
+    )
+    target_configs = SnowflakeTargetConfigs(
+        credentials=connector
+    )
+    dbt_cli_profile = DbtCliProfile(
+        name="jaffle_shop",
+        target="dev",
+        target_configs=target_configs,
+    )
+    result = trigger_dbt_cli_command(
+        "dbt debug",
+        overwrite_profiles=True,
+        dbt_cli_profile=dbt_cli_profile
+    )
+    return result
+
+trigger_dbt_cli_command_flow()
+```
+
 ## Resources
 
 If you encounter any bugs while using `prefect-dbt`, feel free to open an issue in the [prefect-dbt](https://github.com/PrefectHQ/prefect-dbt) repository.

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -11,7 +11,7 @@ from pydantic import Field
 from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
 
 try:
-    from prefect_snowflake.credentials import SnowflakeCredentials
+    from prefect_snowflake.credentials import SnowflakeConnector
 except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Snowflake") from e
 
@@ -40,9 +40,9 @@ class SnowflakeTargetConfigs(TargetConfigs):
         Instantiate SnowflakeTargetConfigs.
         ```python
         from prefect_dbt.cli.configs import SnowflakeTargetConfigs
-        from prefect_snowflake.credentials import SnowflakeCredentials
+        from prefect_snowflake.credentials import SnowflakeConnector
 
-        credentials = SnowflakeCredentials(
+        connector = SnowflakeConnector(
             schema="schema",
             user="user",
             password="password",
@@ -52,7 +52,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
             warehouse="warehouse",
         )
         target_configs = SnowflakeTargetConfigs(
-            credentials=credentials
+            credentials=connector
         )
         ```
     """
@@ -62,7 +62,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
 
     type: Literal["snowflake"] = "snowflake"
     schema_: Optional[str] = Field(default=None, alias="schema")
-    credentials: SnowflakeCredentials
+    credentials: SnowflakeConnector
 
     def get_configs(self) -> Dict[str, Any]:
         """
@@ -75,6 +75,6 @@ class SnowflakeTargetConfigs(TargetConfigs):
         if "schema" not in configs_json:
             raise ValueError(
                 "The keyword, schema, must be provided in either "
-                "SnowflakeCredentials or SnowflakeTargetConfigs"
+                "SnowflakeConnector or SnowflakeTargetConfigs"
             )
         return configs_json

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -72,7 +72,6 @@ class SnowflakeTargetConfigs(TargetConfigs):
             A configs JSON.
         """
         configs_json = super().get_configs()
-        configs_json.pop("connect_params")
         if "schema" not in configs_json:
             raise ValueError(
                 "The keyword, schema, must be provided in either "

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -11,7 +11,7 @@ from pydantic import Field
 from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
 
 try:
-    from prefect_snowflake.credentials import SnowflakeConnector
+    from prefect_snowflake.database import SnowflakeConnector
 except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Snowflake") from e
 
@@ -40,16 +40,20 @@ class SnowflakeTargetConfigs(TargetConfigs):
         Instantiate SnowflakeTargetConfigs.
         ```python
         from prefect_dbt.cli.configs import SnowflakeTargetConfigs
-        from prefect_snowflake.credentials import SnowflakeConnector
+        from prefect_snowflake.credentials import SnowflakeCredentials
+        from prefect_snowflake.database import SnowflakeConnector
 
-        connector = SnowflakeConnector(
-            schema="schema",
+        credentials = SnowflakeCredentials(
             user="user",
             password="password",
-            account="account",
+            account="account.region.aws",
             role="role",
+        )
+        connector = SnowflakeConnector(
+            schema="public",
             database="database",
             warehouse="warehouse",
+            credentials=credentials,
         )
         target_configs = SnowflakeTargetConfigs(
             credentials=connector
@@ -72,9 +76,4 @@ class SnowflakeTargetConfigs(TargetConfigs):
             A configs JSON.
         """
         configs_json = super().get_configs()
-        if "schema" not in configs_json:
-            raise ValueError(
-                "The keyword, schema, must be provided in either "
-                "SnowflakeConnector or SnowflakeTargetConfigs"
-            )
         return configs_json

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md") as readme_file:
 
 extras_require = {
     "cli": ["dbt_core>=1.1.1"],
-    "snowflake": ["prefect-snowflake>=0.1.1"],
+    "snowflake": ["prefect-snowflake>=0.2.0"],
     "bigquery": ["prefect-gcp>=0.1.2"],
     "postgres": ["prefect-sqlalchemy>=0.1.1"],
 }

--- a/tests/cli/configs/test_snowflake.py
+++ b/tests/cli/configs/test_snowflake.py
@@ -1,18 +1,21 @@
-import pytest
-from prefect_snowflake.credentials import SnowflakeConnector
+from prefect_snowflake.credentials import SnowflakeCredentials
+from prefect_snowflake.database import SnowflakeConnector
 from pydantic import SecretBytes, SecretStr
 
 from prefect_dbt.cli.configs import SnowflakeTargetConfigs
 
 
 def test_snowflake_target_configs_get_configs():
-    connector_kwargs = dict(
+    credentials = SnowflakeCredentials(
         account="account",
         user="user",
         password="password",
+    )
+    connector_kwargs = dict(
         schema="schema",
         database="database",
         warehouse="warehouse",
+        credentials=credentials,
     )
 
     snowflake_connector = SnowflakeConnector(**connector_kwargs)
@@ -28,6 +31,7 @@ def test_snowflake_target_configs_get_configs():
         schema="schema",
         database="database",
         warehouse="warehouse",
+        authenticator="snowflake",
         threads=4,
     )
     for k, v in actual.items():
@@ -36,16 +40,3 @@ def test_snowflake_target_configs_get_configs():
         )
         expected_v = expected[k]
         assert actual_v == expected_v
-
-
-def test_snowflake_target_configs_get_configs_missing_schema():
-    snowflake_connector = SnowflakeConnector(
-        account="account",
-        user="user",
-        password="password",
-        database="database",
-        warehouse="warehouse",
-    )
-    configs = SnowflakeTargetConfigs(credentials=snowflake_connector)
-    with pytest.raises(ValueError, match="The keyword, schema"):
-        configs.get_configs()

--- a/tests/cli/configs/test_snowflake.py
+++ b/tests/cli/configs/test_snowflake.py
@@ -1,21 +1,22 @@
 import pytest
-from prefect_snowflake.credentials import SnowflakeCredentials
+from prefect_snowflake.credentials import SnowflakeConnector
 from pydantic import SecretBytes, SecretStr
 
 from prefect_dbt.cli.configs import SnowflakeTargetConfigs
 
 
-@pytest.mark.parametrize("schema_in_target_configs", [True, False])
-def test_snowflake_target_configs_get_configs(schema_in_target_configs):
-    configs_kwargs = dict()
-    credentials_kwargs = dict(account="account", user="user", password="password")
-    if schema_in_target_configs:
-        configs_kwargs["schema"] = "schema"
-    else:
-        credentials_kwargs["schema"] = "schema"
+def test_snowflake_target_configs_get_configs():
+    connector_kwargs = dict(
+        account="account",
+        user="user",
+        password="password",
+        schema="schema",
+        database="database",
+        warehouse="warehouse",
+    )
 
-    snowflake_credentials = SnowflakeCredentials(**credentials_kwargs)
-    configs_kwargs["credentials"] = snowflake_credentials
+    snowflake_connector = SnowflakeConnector(**connector_kwargs)
+    configs_kwargs = {"credentials": snowflake_connector}
 
     configs = SnowflakeTargetConfigs(**configs_kwargs)
     actual = configs.get_configs()
@@ -25,6 +26,8 @@ def test_snowflake_target_configs_get_configs(schema_in_target_configs):
         password="password",
         type="snowflake",
         schema="schema",
+        database="database",
+        warehouse="warehouse",
         threads=4,
     )
     for k, v in actual.items():
@@ -36,18 +39,13 @@ def test_snowflake_target_configs_get_configs(schema_in_target_configs):
 
 
 def test_snowflake_target_configs_get_configs_missing_schema():
-    snowflake_credentials = SnowflakeCredentials(
-        account="account", user="user", password="password"
+    snowflake_connector = SnowflakeConnector(
+        account="account",
+        user="user",
+        password="password",
+        database="database",
+        warehouse="warehouse",
     )
-    configs = SnowflakeTargetConfigs(credentials=snowflake_credentials)
-    with pytest.raises(ValueError, match="The keyword, schema"):
-        configs.get_configs()
-
-
-def test_snowflake_target_configs_get_configs_duplicate_schema():
-    snowflake_credentials = SnowflakeCredentials(
-        account="account", user="user", password="password", schema="schema"
-    )
-    configs = SnowflakeTargetConfigs(credentials=snowflake_credentials, schema="schema")
+    configs = SnowflakeTargetConfigs(credentials=snowflake_connector)
     with pytest.raises(ValueError, match="The keyword, schema"):
         configs.get_configs()


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
The following PR removes self.connect_params and migrates keywords/method to SnowflakeConnector. Wondering if we should rename `credentials` to `block`?
https://github.com/PrefectHQ/prefect-snowflake/pull/24

Do not merge until that PR has been merged

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
