### PR TITLE
Refactors `trigger_dbt_cloud_job_run_and_wait_for_completion`

### DIFF
--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -11,7 +11,7 @@ class DbtConfigs(Block, abc.ABC):
     """
     Abstract class for other dbt Configs.
 
-    Args:
+    Attributes:
         extras: Extra target configs' keywords, not yet added
             to prefect-dbt, but available in dbt; if there are
             duplicate keys between extras and TargetConfigs,
@@ -61,7 +61,7 @@ class TargetConfigs(DbtConfigs):
     https://docs.getdbt.com/docs/available-adapters) page and
     click the desired adapter's "Profile Setup" hyperlink.
 
-    Args:
+    Attributes:
         type: The name of the database warehouse
         schema: The schema that dbt will build objects into;
             in BigQuery, a schema is actually a dataset.
@@ -93,7 +93,7 @@ class GlobalConfigs(DbtConfigs):
     or a failing model. Docs can be found [here](
     https://docs.getdbt.com/reference/global-configs).
 
-    Args:
+    Attributes:
         send_anonymous_usage_stats: Whether usage stats are sent to dbt.
         use_colors: Colorize the output it prints in your terminal.
         partial_parse: When partial parsing is enabled, dbt will use an

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -78,7 +78,7 @@ class TargetConfigs(DbtConfigs):
     """
 
     _block_type_name = "dbt CLI Target Configs"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
 
     type: str
     schema_: str = Field(alias="schema")
@@ -125,7 +125,7 @@ class GlobalConfigs(DbtConfigs):
     """
 
     _block_type_name = "dbt CLI Global Configs"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
 
     send_anonymous_usage_stats: Optional[bool] = None
     use_colors: Optional[bool] = None

--- a/prefect_dbt/cli/configs/bigquery.py
+++ b/prefect_dbt/cli/configs/bigquery.py
@@ -77,7 +77,7 @@ class BigQueryTargetConfigs(TargetConfigs):
     """
 
     _block_type_name = "dbt CLI BigQuery Target Configs"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
     _description = "dbt CLI target configs containing credentials and settings, specific to BigQuery."  # noqa
 
     type: Literal["bigquery"] = "bigquery"

--- a/prefect_dbt/cli/configs/bigquery.py
+++ b/prefect_dbt/cli/configs/bigquery.py
@@ -22,7 +22,7 @@ class BigQueryTargetConfigs(TargetConfigs):
     https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile)
     page.
 
-    Args:
+    Attributes:
         credentials: The credentials to use to authenticate; if there are
             duplicate keys between credentials and TargetConfigs,
             e.g. schema, an error will be raised.

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -53,7 +53,7 @@ class PostgresTargetConfigs(TargetConfigs):
     """
 
     _block_type_name = "dbt CLI Postgres Target Configs"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
     _description = "dbt CLI target configs containing credentials and settings specific to Postgres."  # noqa
 
     type: Literal["postgres"] = "postgres"

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -22,7 +22,7 @@ class PostgresTargetConfigs(TargetConfigs):
     https://docs.getdbt.com/reference/warehouse-profiles/postgres-profile)
     page.
 
-    Args:
+    Attributes:
         credentials: The credentials to use to authenticate; if there are
             duplicate keys between credentials and TargetConfigs,
             e.g. schema, an error will be raised.

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -24,7 +24,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
     https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile)
     page.
 
-    Args:
+    Attributes:
         credentials: The credentials to use to authenticate; if there are
             duplicate keys between credentials and TargetConfigs,
             e.g. schema, an error will be raised.

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -62,7 +62,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
     """
 
     _block_type_name = "dbt CLI Snowflake Target Configs"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
 
     type: Literal["snowflake"] = "snowflake"
     schema_: Optional[str] = Field(default=None, alias="schema")

--- a/prefect_dbt/cli/credentials.py
+++ b/prefect_dbt/cli/credentials.py
@@ -86,7 +86,7 @@ class DbtCliProfile(Block):
     """
 
     _block_type_name = "dbt CLI Profile"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
 
     name: str
     target: str

--- a/prefect_dbt/cli/credentials.py
+++ b/prefect_dbt/cli/credentials.py
@@ -10,7 +10,7 @@ class DbtCliProfile(Block):
     """
     Profile for use across dbt CLI tasks and flows.
 
-    Args:
+    Attributes:
         name (str): Profile name used for populating profiles.yml.
         target (str): The default target your dbt project will use.
         target_configs (TargetConfigs): Target configs contain credentials and

--- a/prefect_dbt/cloud/credentials.py
+++ b/prefect_dbt/cloud/credentials.py
@@ -53,7 +53,7 @@ class DbtCloudCredentials(Block):
     """
 
     _block_type_name = "dbt Cloud Credentials"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/9a001902ed43a84c6c96d23b24622e19/dbt-bit_tm.png?h=250"  # noqa
 
     api_key: SecretStr
     account_id: int

--- a/prefect_dbt/cloud/credentials.py
+++ b/prefect_dbt/cloud/credentials.py
@@ -9,7 +9,7 @@ class DbtCloudCredentials(Block):
     """
     Credentials block for credential use across dbt Cloud tasks and flows.
 
-    Args:
+    Attributes:
         api_key (SecretStr): API key to authenticate with the dbt Cloud
             administrative API. Refer to the [Authentication docs](
             https://docs.getdbt.com/dbt-cloud/api-v2#section/Authentication)

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -138,6 +138,31 @@ def get_run_id(obj: Dict):
 
     Args:
         obj: The JSON body from the trigger job run response.
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect_dbt.cloud import DbtCloudCredentials
+        from prefect_dbt.cloud.jobs import trigger_dbt_cloud_job_run, get_run_id
+
+
+        @flow
+        def trigger_run_and_get_id():
+            dbt_cloud_credentials=DbtCloudCredentials(
+                    api_key="my_api_key",
+                    account_id=123456789
+                )
+
+            triggered_run_data = trigger_dbt_cloud_job_run(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                job_id=job_id,
+                options=trigger_job_run_options,
+            )
+            run_id = get_run_id.submit(triggered_run_data)
+            return run_id
+
+        trigger_run_and_get_id()
+        ```
     """
     id = obj.get("id")
     if id is None:
@@ -297,5 +322,5 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
     else:
         raise RuntimeError(
             f"Triggered job run with ID: {run_id_future.result()} ended with unexpected"
-            f"status {final_run_status.value}."
+            "status {final_run_status.value}."
         )

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -1,6 +1,4 @@
 """Module containing tasks and flows for interacting with dbt Cloud jobs"""
-import asyncio
-from enum import Enum
 from typing import Dict, Optional
 
 from httpx import HTTPStatusError
@@ -9,9 +7,12 @@ from prefect import flow, get_run_logger, task
 from prefect_dbt.cloud.credentials import DbtCloudCredentials
 from prefect_dbt.cloud.models import TriggerJobRunOptions
 from prefect_dbt.cloud.runs import (
+    DbtCloudJobRunCancelled,
+    DbtCloudJobRunFailed,
+    DbtCloudJobRunStatus,
     DbtCloudListRunArtifactsFailed,
-    get_dbt_cloud_run_info,
     list_dbt_cloud_run_artifacts,
+    wait_for_dbt_cloud_job_run,
 )
 from prefect_dbt.cloud.utils import extract_user_message
 
@@ -20,46 +21,6 @@ class DbtCloudJobRunTriggerFailed(Exception):
     """Raised when a dbt Cloud job trigger fails"""
 
     pass
-
-
-class DbtCloudJobRunFailed(Exception):
-    """Raised when a triggered job run fails"""
-
-    pass
-
-
-class DbtCloudJobRunCancelled(Exception):
-    """Raised when a triggered job run is cancelled"""
-
-    pass
-
-
-class DbtCloudJobRunTimedOut(Exception):
-    """
-    Raised when a triggered job run does not complete in the configured max
-    wait seconds
-    """
-
-    pass
-
-
-class DbtCloudJobRunStatus(Enum):
-    """dbt Cloud Job statuses."""
-
-    QUEUED = 1
-    STARTING = 2
-    RUNNING = 3
-    SUCCESS = 10
-    FAILED = 20
-    CANCELLED = 30
-
-    @classmethod
-    def is_terminal_status_code(cls, status_code: int) -> bool:
-        """
-        Returns True if a status code is terminal for a job run.
-        Return False otherwise.
-        """
-        return status_code in [cls.SUCCESS.value, cls.FAILED.value, cls.CANCELLED.value]
 
 
 @task(
@@ -164,6 +125,26 @@ async def trigger_dbt_cloud_job_run(
     return run_data
 
 
+@task(
+    name="Get dbt Cloud job run ID",
+    description="Extracts the run ID from a trigger job run API response",
+)
+def get_run_id(obj: Dict):
+    """
+    Task that extracts the run ID from a trigger job run API response,
+
+    This task is mainly used to maintain dependency tracking between the
+    `trigger_dbt_cloud_job_run` task and downstream tasks/flows that use the run ID.
+
+    Args:
+        obj: The JSON body from the trigger job run response.
+    """
+    id = obj.get("id")
+    if id is None:
+        raise RuntimeError("Unable to determine run ID for triggered job.")
+    return id
+
+
 @flow(
     name="Trigger dbt Cloud job run and wait for completion",
     description="Triggers a dbt Cloud job run and waits for the"
@@ -187,6 +168,11 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
         max_wait_seconds: Maximum number of seconds to wait for job to complete
         poll_frequency_seconds: Number of seconds to wait in between checks for
             run completion.
+
+    Raises:
+        DbtCloudJobRunCancelled: The triggered dbt Cloud job run was cancelled.
+        DbtCloudJobRunFailed: The triggered dbt Cloud job run failed.
+        RuntimeError: The triggered dbt Cloud job run ended in an unexpected state.
 
     Returns:
         The run data returned by the dbt Cloud administrative API.
@@ -273,51 +259,43 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
         job_id=job_id,
         options=trigger_job_run_options,
     )
-    triggered_run_data = await triggered_run_data_future.result()
-    run_id = triggered_run_data["id"]
+    run_id_future = get_run_id.submit(triggered_run_data_future)
 
-    seconds_waited_for_run_completion = 0
-    while seconds_waited_for_run_completion <= max_wait_seconds:
-        run_data_future = await get_dbt_cloud_run_info.submit(
-            dbt_cloud_credentials=dbt_cloud_credentials,
-            run_id=run_id,
-            wait_for=[triggered_run_data_future],
-        )
-        run_data = await run_data_future.result()
-        run_status_code = run_data.get("status")
+    final_run_status, run_data = await wait_for_dbt_cloud_job_run(
+        run_id=run_id_future,
+        dbt_cloud_credentials=dbt_cloud_credentials,
+        max_wait_seconds=max_wait_seconds,
+        poll_frequency_seconds=poll_frequency_seconds,
+    )
 
-        if run_status_code == DbtCloudJobRunStatus.SUCCESS.value:
-            try:
-                list_run_artifacts_future = await list_dbt_cloud_run_artifacts.submit(
-                    dbt_cloud_credentials=dbt_cloud_credentials,
-                    run_id=run_id,
-                    wait_for=[run_data_future],
-                )
-                run_data["artifact_paths"] = await list_run_artifacts_future.result()
-            except DbtCloudListRunArtifactsFailed as ex:
-                logger.warning(
-                    "Unable to retrieve artifacts for job run with ID %s. Reason: %s",
-                    run_id,
-                    ex,
-                )
-            logger.info("dbt Cloud job run with ID %s completed successfully!", run_id)
-            return run_data
-        elif run_status_code == DbtCloudJobRunStatus.FAILED.value:
-            raise DbtCloudJobRunFailed(f"Triggered job run with ID: {run_id} failed.")
-        elif run_status_code == DbtCloudJobRunStatus.CANCELLED.value:
-            raise DbtCloudJobRunCancelled(
-                f"Triggered job run with ID {run_id} was cancelled."
+    if final_run_status == DbtCloudJobRunStatus.SUCCESS:
+        try:
+            list_run_artifacts_future = await list_dbt_cloud_run_artifacts.submit(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                run_id=run_id_future,
+            )
+            run_data["artifact_paths"] = await list_run_artifacts_future.result()
+        except DbtCloudListRunArtifactsFailed as ex:
+            logger.warning(
+                "Unable to retrieve artifacts for job run with ID %s. Reason: %s",
+                run_id_future.result(),
+                ex,
             )
         logger.info(
-            "dbt Cloud job run with ID %i has status %s. Waiting for %i seconds.",
-            run_id,
-            DbtCloudJobRunStatus(run_status_code).name,
-            poll_frequency_seconds,
+            "dbt Cloud job run with ID %s completed successfully!",
+            run_id_future.result(),
         )
-        await asyncio.sleep(poll_frequency_seconds)
-        seconds_waited_for_run_completion += poll_frequency_seconds
-
-    raise DbtCloudJobRunTimedOut(
-        f"Max wait time of {max_wait_seconds} seconds exceeded while waiting "
-        "for job run with ID {run_id}"
-    )
+        return run_data
+    elif final_run_status == DbtCloudJobRunStatus.CANCELLED:
+        raise DbtCloudJobRunCancelled(
+            f"Triggered job run with ID {run_id_future.result()} was cancelled."
+        )
+    elif final_run_status == DbtCloudJobRunStatus.FAILED:
+        raise DbtCloudJobRunFailed(
+            f"Triggered job run with ID: {run_id_future.result()} failed."
+        )
+    else:
+        raise RuntimeError(
+            f"Triggered job run with ID: {run_id_future.result()} ended with unexpected"
+            f"status {final_run_status.value}."
+        )

--- a/prefect_dbt/cloud/runs.py
+++ b/prefect_dbt/cloud/runs.py
@@ -260,7 +260,10 @@ async def get_dbt_cloud_run_artifact(
     return artifact_contents
 
 
-@flow
+@flow(
+    name="Wait for dbt Cloud job run",
+    description="Waits for a dbt Cloud job run to finish running.",
+)
 async def wait_for_dbt_cloud_job_run(
     run_id: int,
     dbt_cloud_credentials: DbtCloudCredentials,
@@ -268,7 +271,7 @@ async def wait_for_dbt_cloud_job_run(
     poll_frequency_seconds: int = 10,
 ) -> Tuple[DbtCloudJobRunStatus, Dict]:
     """
-    Wait for the given dbt Cloud job run to finish running.
+    Waits for the given dbt Cloud job run to finish running.
 
     Args:
         run_id: The ID of the run to wait for.

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -9,12 +9,12 @@ from prefect_dbt.cloud.credentials import DbtCloudCredentials
 from prefect_dbt.cloud.jobs import (
     DbtCloudJobRunCancelled,
     DbtCloudJobRunFailed,
-    DbtCloudJobRunTimedOut,
     DbtCloudJobRunTriggerFailed,
     trigger_dbt_cloud_job_run,
     trigger_dbt_cloud_job_run_and_wait_for_completion,
 )
 from prefect_dbt.cloud.models import TriggerJobRunOptions
+from prefect_dbt.cloud.runs import DbtCloudJobRunTimedOut
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Refactors `trigger_dbt_cloud_job_run_and_wait_for_completion` for better display in radar UI. This is accomplished by moving all tasks that check for run status into a subflow for grouping in radar, and creating a `get_id` task to preserve task dependencies between the trigger task and other downstream operations.

Here's what the radar graph looks like for the flow now:
![Screen Shot 2022-08-23 at 4 24 29 PM](https://user-images.githubusercontent.com/12350579/186269036-01f1090f-1887-433d-8331-ee7c8b315dd5.png)

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
