### PR TITLE
Restrict extra fields and improve logic for selecting proper fields to populate profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes `TargetConfigs.load("BLOCK_NAME").get_configs()` by ignoring private attributes - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
+
 ### Security
 
 ## 0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `TargetConfigs` now forbids unexpected fields; utilize the `extras` field instead - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- Fixes `TargetConfigs.load("BLOCK_NAME").get_configs()` by ignoring private attributes and base `Block` fields - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
+- Fixes `TargetConfigs.load("BLOCK_NAME").get_configs()` by passing only `TargetConfigs.__fields__` - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes `TargetConfigs.load("BLOCK_NAME").get_configs()` by ignoring private attributes - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
+- Fixes `TargetConfigs.load("BLOCK_NAME").get_configs()` by ignoring private attributes and base `Block` fields - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # prefect-dbt
 
+<p align="center">
+    <a href="https://pypi.python.org/pypi/prefect-dbt/" alt="PyPI version">
+        <img alt="PyPI" src="https://img.shields.io/pypi/v/prefect-dbt?color=0052FF&labelColor=090422"></a>
+    <a href="https://github.com/prefecthq/prefect-dbt/" alt="Stars">
+        <img src="https://img.shields.io/github/stars/prefecthq/prefect-dbt?color=0052FF&labelColor=090422" /></a>
+    <a href="https://pepy.tech/badge/prefect-dbt/" alt="Downloads">
+        <img src="https://img.shields.io/pypi/dm/prefect-dbt?color=0052FF&labelColor=090422" /></a>
+    <a href="https://github.com/prefecthq/prefect-dbt/pulse" alt="Activity">
+        <img src="https://img.shields.io/github/commit-activity/m/prefecthq/prefect-dbt?color=0052FF&labelColor=090422" /></a>
+    <br>
+    <a href="https://prefect-community.slack.com" alt="Slack">
+        <img src="https://img.shields.io/badge/slack-join_community-red.svg?color=0052FF&labelColor=090422&logo=slack" /></a>
+    <a href="https://discourse.prefect.io/" alt="Discourse">
+        <img src="https://img.shields.io/badge/discourse-browse_forum-red.svg?color=0052FF&labelColor=090422&logo=discourse" /></a>
+</p>
+
 ## Welcome!
 
 `prefect-dbt` is a collection of Prefect integrations for working with dbt with your Prefect flows.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ def trigger_dbt_cli_command_flow():
         ),
     )
     target_configs = SnowflakeTargetConfigs(
-        connector=connector
+        credentials=connector
     )
     dbt_cli_profile = DbtCliProfile(
         name="jaffle_shop",

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -47,7 +47,7 @@ class DbtConfigs(Block, abc.ABC, extra=Extra.forbid):
                 configs_json = self._populate_configs_json(
                     configs_json, field_value.__fields__, model=field_value
                 )
-            elif isinstance(field_value, dict):
+            elif field_name == "extras":
                 configs_json = self._populate_configs_json(configs_json, field_value)
             else:
                 if field_name in configs_json.keys():

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -26,8 +26,10 @@ class DbtConfigs(Block, abc.ABC):
         """
         Recursively populate configs_json.
         """
+        invalid_keys = Block().dict().keys()
+
         for key, value in dict_.items():
-            if key.startswith("_"):
+            if key in invalid_keys or key.startswith("_"):
                 continue
 
             # key needs to be rstripped because schema alias doesn't get used
@@ -44,6 +46,7 @@ class DbtConfigs(Block, abc.ABC):
                     if isinstance(value, (SecretStr, SecretBytes)):
                         value = value.get_secret_value()
                     configs_json[key] = value
+        print(configs_json)
         return configs_json
 
     def get_configs(self) -> Dict[str, Any]:

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -27,6 +27,9 @@ class DbtConfigs(Block, abc.ABC):
         Recursively populate configs_json.
         """
         for key, value in dict_.items():
+            if key.startswith("_"):
+                continue
+
             # key needs to be rstripped because schema alias doesn't get used
             key = key.rstrip("_")
             if value is not None:

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -46,7 +46,7 @@ class DbtConfigs(Block, abc.ABC):
                     if isinstance(value, (SecretStr, SecretBytes)):
                         value = value.get_secret_value()
                     configs_json[key] = value
-        print(configs_json)
+
         return configs_json
 
     def get_configs(self) -> Dict[str, Any]:

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -79,7 +79,7 @@ class PostgresTargetConfigs(TargetConfigs):
         for invalid_key in invalid_keys + list(rename_keys):
             configs_json.pop(invalid_key, None)
 
-        rendered_url = configs_json.pop("rendered_url")
+        rendered_url = self.credentials.rendered_url
         for key in rename_keys:
             renamed_key = rename_keys[key]
             configs_json[renamed_key] = getattr(rendered_url, key)

--- a/tests/cli/configs/test_base.py
+++ b/tests/cli/configs/test_base.py
@@ -1,6 +1,12 @@
 import pytest
+from pydantic import ValidationError
 
-from prefect_dbt.cli.configs.base import TargetConfigs
+from prefect_dbt.cli.configs.base import DbtConfigs, TargetConfigs
+
+
+def test_dbt_configs_forbid_extra():
+    with pytest.raises(ValidationError, match="extra fields not"):
+        DbtConfigs(some_field="not going to happen")
 
 
 def test_target_configs_get_configs():
@@ -9,7 +15,6 @@ def test_target_configs_get_configs():
         schema="schema_input",
         threads=5,
         extras={"extra_input": 1, "null_input": None},
-        _is_anonymous=False,
     )
     assert hasattr(target_configs, "_is_anonymous")
     # get_configs ignore private attrs

--- a/tests/cli/configs/test_base.py
+++ b/tests/cli/configs/test_base.py
@@ -9,7 +9,10 @@ def test_target_configs_get_configs():
         schema="schema_input",
         threads=5,
         extras={"extra_input": 1, "null_input": None},
+        _is_anonymous=False,
     )
+    assert hasattr(target_configs, "_is_anonymous")
+    # get_configs ignore private attrs
     assert target_configs.get_configs() == dict(
         type="snowflake", schema="schema_input", threads=5, extra_input=1
     )

--- a/tests/cli/configs/test_bigquery.py
+++ b/tests/cli/configs/test_bigquery.py
@@ -29,6 +29,23 @@ def test_gcp_target_configs_get_configs(project_in_target_configs):
     assert actual == expected
 
 
+def test_gcp_target_configs_get_configs_service_account_info():
+    gcp_credentials = GcpCredentials(service_account_info={"my": "secrets"})
+    configs = BigQueryTargetConfigs(
+        credentials=gcp_credentials, project="my_project", schema="my_schema"
+    )
+    actual = configs.get_configs()
+    expected = {
+        "type": "bigquery",
+        "schema": "my_schema",
+        "threads": 4,
+        "project": "my_project",
+        "method": "service-account-json",
+        "keyfile_json": {"my": "secrets"},
+    }
+    assert actual == expected
+
+
 def test_gcp_target_configs_get_configs_missing_schema():
     gcp_credentials = GcpCredentials(service_account_file="service_account_file")
     configs = BigQueryTargetConfigs(credentials=gcp_credentials, schema="schema")

--- a/tests/cli/configs/test_bigquery.py
+++ b/tests/cli/configs/test_bigquery.py
@@ -30,7 +30,7 @@ def test_gcp_target_configs_get_configs(project_in_target_configs):
 
 
 def test_gcp_target_configs_get_configs_service_account_info():
-    gcp_credentials = GcpCredentials(service_account_info={"my": "secrets"})
+    gcp_credentials = GcpCredentials(service_account_info='{"my": "secrets"}')
     configs = BigQueryTargetConfigs(
         credentials=gcp_credentials, project="my_project", schema="my_schema"
     )

--- a/tests/cli/test_credentials.py
+++ b/tests/cli/test_credentials.py
@@ -24,7 +24,9 @@ def test_dbt_cli_profile_init(configs_type):
 
 def test_dbt_cli_profile_init_validation_failed():
     with pytest.raises(ValidationError, match="2 validation errors for DbtCliProfile"):
-        DbtCliProfile(name="test_name", target="dev", target_configs={"field": "abc"})
+        DbtCliProfile(
+            name="test_name", target="dev", target_configs={"extras": {"field": "abc"}}
+        )
 
 
 def test_dbt_cli_profile_get_profile():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,16 +14,18 @@ def dbt_cloud_credentials():
 def dbt_cli_profile():
     target_configs = TargetConfigs(
         type="snowflake",
-        account="account",
-        user="user",
-        password="password",
-        role="role",
-        database="database",
-        warehouse="warehouse",
         schema="schema",
         threads=4,
-        client_session_keep_alive=False,
-        query_tag="query_tag",
+        extras=dict(
+            account="account",
+            user="user",
+            password="password",
+            role="role",
+            database="database",
+            warehouse="warehouse",
+            client_session_keep_alive=False,
+            query_tag="query_tag",
+        ),
     )
     global_configs = GlobalConfigs(
         send_anonymous_usage_stats=False,
@@ -50,9 +52,7 @@ def dbt_cli_profile():
 @pytest.fixture
 def dbt_cli_profile_bare():
     target_configs = TargetConfigs(
-        type="custom",
-        schema="schema",
-        account="fake",
+        type="custom", schema="schema", extras={"account": "fake"}
     )
     return DbtCliProfile(
         name="prefecto",


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
Use the __fields__ attribute since it doesn’t have block_type_slug, but contains all the relevant fields to a target config.
![image](https://user-images.githubusercontent.com/15331990/191087405-7ca3e197-6530-49bb-bb3c-dfc73f5a2922.png)

Also bounds fields allowed in `DbtConfigs` since the field `extras` should be the only way.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes https://github.com/PrefectHQ/prefect-dbt/issues/59

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
