### PR TITLE
Explicitly include exclude fields for config

### DIFF
--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -31,10 +31,9 @@ class DbtConfigs(Block, abc.ABC):
         Recursively populate configs_json.
         """
         for key, value in dict_.items():
-            # must use exclude fields here because of nesting;
-            # e.g. `CredentialsTargetConfigs` contains `Credentials`
-            # and `block_type_slug` is inside Credentials
-            if key.startswith("_") or key in self._exclude_fields:
+            if self._include_fields and key not in self._include_fields:
+                continue
+            elif self._exclude_fields and key in self._exclude_fields:
                 continue
 
             # key needs to be rstripped because schema alias doesn't get used
@@ -60,13 +59,7 @@ class DbtConfigs(Block, abc.ABC):
         Returns:
             A configs JSON.
         """
-        include = None
-        if self._include_fields:
-            include = set(self._include_fields + self._nested_fields)
-
-        # cannot use exclude here; see note in _populate_configs_json
-        subset_dict = self.dict(include=include)
-        return self._populate_configs_json({}, subset_dict)
+        return self._populate_configs_json({}, self.dict())
 
 
 class TargetConfigs(DbtConfigs):

--- a/prefect_dbt/cli/configs/bigquery.py
+++ b/prefect_dbt/cli/configs/bigquery.py
@@ -6,7 +6,10 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
+from prefect_dbt.cli.configs.base import (
+    CredentialsTargetConfigs,
+    MissingExtrasRequireError,
+)
 
 try:
     from prefect_gcp.credentials import GcpCredentials
@@ -14,7 +17,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("BigQuery") from e
 
 
-class BigQueryTargetConfigs(TargetConfigs):
+class BigQueryTargetConfigs(CredentialsTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to BigQuery.
@@ -79,6 +82,7 @@ class BigQueryTargetConfigs(TargetConfigs):
     _block_type_name = "dbt CLI BigQuery Target Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
     _description = "dbt CLI target configs containing credentials and settings, specific to BigQuery."  # noqa
+    _include_fields = ("project",) + CredentialsTargetConfigs._include_fields
 
     type: Literal["bigquery"] = "bigquery"
     project: Optional[str] = None

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -6,7 +6,10 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
+from prefect_dbt.cli.configs.base import (
+    CredentialsTargetConfigs,
+    MissingExtrasRequireError,
+)
 
 try:
     from prefect_sqlalchemy.credentials import DatabaseCredentials
@@ -14,7 +17,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Postgres") from e
 
 
-class PostgresTargetConfigs(TargetConfigs):
+class PostgresTargetConfigs(CredentialsTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to Postgres.

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -8,7 +8,10 @@ except ImportError:
 
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
+from prefect_dbt.cli.configs.base import (
+    CredentialsTargetConfigs,
+    MissingExtrasRequireError,
+)
 
 try:
     from prefect_snowflake.database import SnowflakeConnector
@@ -16,7 +19,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Snowflake") from e
 
 
-class SnowflakeTargetConfigs(TargetConfigs):
+class SnowflakeTargetConfigs(CredentialsTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to Snowflake.
@@ -63,6 +66,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
 
     _block_type_name = "dbt CLI Snowflake Target Configs"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/5zE9lxfzBHjw3tnEup4wWL/8cb73be51575a659667f6471a24153f5/dbt-bit_tm.png?h=250"  # noqa
+    _nested_fields = ("connector",) + CredentialsTargetConfigs._nested_fields
 
     type: Literal["snowflake"] = "snowflake"
     schema_: Optional[str] = Field(default=None, alias="schema")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def dbt_cli_profile_bare():
     target_configs = TargetConfigs(
         type="custom",
         schema="schema",
-        account="fake",
+        extras={"account": "fake"},
     )
     return DbtCliProfile(
         name="prefecto",


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Add explicit include / exclude. Not sure if we want to do this since it adds a bit of redundancy, e.g. when adding fields, need to list field in `_include_fields` and defining the field.

Also, I must add `_exclude_fields` (can't solely use `Block().dict()` and/or `_include_fields`) due to nesting of `credentials`, e.g. `GcpCredentials` contains `block_type_slug` and the include functionality does not ignore nested values.

I prefer the `ignore_private_attrs` branch better since we still need to set `block_type_slug` in `_exclude_fields`.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
