### PR TITLE
Fix loading of blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
 ### Changed
+
+- `TargetConfigs` now allows unexpected fields again because block attributes were not being saved - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
+
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `TargetConfigs` now allows unexpected fields again because block attributes were not being saved - [#60](https://github.com/PrefectHQ/prefect-dbt/pull/60)
+- `TargetConfigs` now allows unexpected fields again because block attributes were not being saved - [#64](https://github.com/PrefectHQ/prefect-dbt/pull/64)
 
 
 ### Deprecated

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -4,10 +4,10 @@ import abc
 from typing import Any, Dict, Optional
 
 from prefect.blocks.core import Block
-from pydantic import BaseModel, Extra, Field, SecretBytes, SecretStr
+from pydantic import BaseModel, Field, SecretBytes, SecretStr
 
 
-class DbtConfigs(Block, abc.ABC, extra=Extra.forbid):
+class DbtConfigs(Block, abc.ABC):
     """
     Abstract class for other dbt Configs.
 

--- a/tests/cli/configs/test_base.py
+++ b/tests/cli/configs/test_base.py
@@ -1,12 +1,6 @@
 import pytest
-from pydantic import ValidationError
 
-from prefect_dbt.cli.configs.base import DbtConfigs, TargetConfigs
-
-
-def test_dbt_configs_forbid_extra():
-    with pytest.raises(ValidationError, match="extra fields not"):
-        DbtConfigs(some_field="not going to happen")
+from prefect_dbt.cli.configs.base import TargetConfigs
 
 
 def test_target_configs_get_configs():


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->


With the latest release of v0.2.1, defining target configs in code and get_configs worked.
```
from prefect import flow
from prefect_dbt.cli.configs import SnowflakeTargetConfigs
from prefect_snowflake.credentials import SnowflakeCredentials
from prefect_snowflake.database import SnowflakeConnector

@flow()
def test_flow():
    credentials = SnowflakeCredentials(
        user="user",
        password="password",
        account="account.region.aws",
        role="role",
    )
    connector = SnowflakeConnector(
        schema="public",
        database="database",
        warehouse="warehouse",
        credentials=credentials,
    )
    target_configs = SnowflakeTargetConfigs(
        connector=connector
    )
    return target_configs.get_configs()

print(test_flow())
```

However, when loading:
```python
>>> from prefect_dbt.cli.configs import SnowflakeTargetConfigs
>>>
>>> snowflake_target_configs = SnowflakeTargetConfigs.load("my-snowflake")
```
Outputs:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/andrew/Applications/python/prefect/src/prefect/utilities/asyncutils.py", line 212, in wrapper
    return run_async_in_new_loop(async_fn, *args, **kwargs)
  File "/Users/andrew/Applications/python/prefect/src/prefect/utilities/asyncutils.py", line 141, in run_async_in_new_loop
    return anyio.run(partial(__fn, *args, **kwargs))
  File "/Users/andrew/mambaforge/envs/prefect-dbt/lib/python3.10/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/Users/andrew/mambaforge/envs/prefect-dbt/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/Users/andrew/mambaforge/envs/prefect-dbt/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/andrew/mambaforge/envs/prefect-dbt/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/Users/andrew/mambaforge/envs/prefect-dbt/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
  File "/Users/andrew/Applications/python/prefect/src/prefect/blocks/core.py", line 652, in load
    return cls._from_block_document(block_document)
  File "/Users/andrew/Applications/python/prefect/src/prefect/blocks/core.py", line 554, in _from_block_document
    block._block_document_id = block_document.id
  File "pydantic/main.py", line 358, in pydantic.main.BaseModel.__setattr__
ValueError: "SnowflakeTargetConfigs" object has no field "_block_document_id"
```

Apparently, cannot forbid extra fields.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
