### PR TITLE
Removes sync task call from `trigger_dbt_cloud_job_run_and_wait_for_completion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `BigQueryTargetConfigs.project` now overrides `GcpCredential.project` rather than error - [#68](https://github.com/PrefectHQ/prefect-dbt/pull/68)
+- `trigger_dbt_cloud_job_run_and_wait_for_completion` no longer hangs when called from a synchronous flow = [#71](https://github.com/PrefectHQ/prefect-dbt/pull/71)
 
 ### Security
 

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -322,5 +322,5 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
     else:
         raise RuntimeError(
             f"Triggered job run with ID: {run_id} ended with unexpected"
-            "status {final_run_status.value}."
+            f"status {final_run_status.value}."
         )

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -147,6 +147,38 @@ class TestTriggerDbtCloudJobRunAndWaitForCompletion:
             "artifact_paths": ["manifest.json"],
         }
 
+    def test_run_in_sync_flow(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.post(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/jobs/1/run/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(
+            return_value=Response(
+                200, json={"data": {"id": 10000, "project_id": 12345}}
+            )
+        )
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/10000/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": {"id": 10000, "status": 10}}))
+        respx_mock.get(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/runs/10000/artifacts/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": ["manifest.json"]}))
+
+        @flow
+        def test_sync_flow():
+            return trigger_dbt_cloud_job_run_and_wait_for_completion(
+                dbt_cloud_credentials=dbt_cloud_credentials, job_id=1
+            )
+
+        result = test_sync_flow()
+
+        assert result == {
+            "id": 10000,
+            "status": 10,
+            "artifact_paths": ["manifest.json"],
+        }
+
     @pytest.mark.respx(assert_all_called=True)
     async def test_run_success_with_wait(self, respx_mock, dbt_cloud_credentials):
         respx_mock.post(


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-dbt! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Refactors `trigger_dbt_cloud_job_run_and_wait_for_completion` to avoid making a synchronous task run from an async flow which can result in the issue reported in https://github.com/PrefectHQ/prefect/issues/7040. The only impact to the flow is a change in how the flow will be displayed in the radar UI.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
Closes #67 
Closes #62 

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
