### PR TITLE
Fix checking run ID in proper location

### DIFF
--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -113,6 +113,8 @@ async def trigger_dbt_cloud_job_run(
         raise DbtCloudJobRunTriggerFailed(extract_user_message(ex)) from ex
 
     run_data = response.json()["data"]
+    if run_data.get("id") is None:
+        raise RuntimeError("Unable to determine run ID for triggered job.")
 
     logger.info(
         f"Run successfully triggered for job with ID {job_id}. "
@@ -285,8 +287,6 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
         options=trigger_job_run_options,
     )
     run_id = (await triggered_run_data_future.result()).get("id")
-    if id is None:
-        raise RuntimeError("Unable to determine run ID for triggered job.")
 
     final_run_status, run_data = await wait_for_dbt_cloud_job_run(
         run_id=run_id,

--- a/prefect_dbt/cloud/jobs.py
+++ b/prefect_dbt/cloud/jobs.py
@@ -113,16 +113,15 @@ async def trigger_dbt_cloud_job_run(
         raise DbtCloudJobRunTriggerFailed(extract_user_message(ex)) from ex
 
     run_data = response.json()["data"]
-    if run_data.get("id") is None:
-        raise RuntimeError("Unable to determine run ID for triggered job.")
 
-    logger.info(
-        f"Run successfully triggered for job with ID {job_id}. "
-        "You can view the status of this run at "
-        f"https://{dbt_cloud_credentials.domain}/#/accounts/"
-        f"{dbt_cloud_credentials.account_id}/projects/{run_data['project_id']}/"
-        f"runs/{run_data['id']}/"
-    )
+    if "project_id" in run_data and "id" in run_data:
+        logger.info(
+            f"Run successfully triggered for job with ID {job_id}. "
+            "You can view the status of this run at "
+            f"https://{dbt_cloud_credentials.domain}/#/accounts/"
+            f"{dbt_cloud_credentials.account_id}/projects/{run_data['project_id']}/"
+            f"runs/{run_data['id']}/"
+        )
 
     return run_data
 
@@ -287,6 +286,8 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
         options=trigger_job_run_options,
     )
     run_id = (await triggered_run_data_future.result()).get("id")
+    if run_id is None:
+        raise RuntimeError("Unable to determine run ID for triggered job.")
 
     final_run_status, run_data = await wait_for_dbt_cloud_job_run(
         run_id=run_id,

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -117,14 +117,16 @@ class TestTriggerDbtCloudJobRun:
         with pytest.raises(DbtCloudJobRunTriggerFailed, match="Not found!"):
             await test_trigger_nonexistent_job()
 
-    async def test_trigger_nonexistent_run_id(self, respx_mock, dbt_cloud_credentials):
+    async def test_trigger_nonexistent_run_id_no_logs(
+        self, respx_mock, dbt_cloud_credentials, caplog
+    ):
         respx_mock.post(
             "https://cloud.getdbt.com/api/v2/accounts/123456789/jobs/1/run/",
             headers={"Authorization": "Bearer my_api_key"},
         ).mock(return_value=Response(200, json={"data": {"project_id": 12345}}))
 
         @flow
-        async def test_trigger_nonexistent_run_id_flow():
+        async def trigger_nonexistent_run_id():
             task_shorter_retry = trigger_dbt_cloud_job_run.with_options(
                 retries=1, retry_delay_seconds=1
             )
@@ -133,8 +135,7 @@ class TestTriggerDbtCloudJobRun:
                 job_id=1,
             )
 
-        with pytest.raises(RuntimeError, match="Unable to determine run ID"):
-            await test_trigger_nonexistent_run_id_flow()
+        await trigger_nonexistent_run_id()
 
 
 class TestTriggerDbtCloudJobRunAndWaitForCompletion:
@@ -256,6 +257,20 @@ class TestTriggerDbtCloudJobRunAndWaitForCompletion:
         )
 
         with pytest.raises(DbtCloudJobRunFailed):
+            await trigger_dbt_cloud_job_run_and_wait_for_completion(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                job_id=1,
+                poll_frequency_seconds=1,
+            )
+
+    @pytest.mark.respx(assert_all_called=True)
+    async def test_run_failure_no_run_id(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.post(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/jobs/1/run/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": {"project_id": 12345}}))
+
+        with pytest.raises(RuntimeError, match="Unable to determine run ID"):
             await trigger_dbt_cloud_job_run_and_wait_for_completion(
                 dbt_cloud_credentials=dbt_cloud_credentials,
                 job_id=1,

--- a/tests/cloud/test_jobs.py
+++ b/tests/cloud/test_jobs.py
@@ -117,6 +117,25 @@ class TestTriggerDbtCloudJobRun:
         with pytest.raises(DbtCloudJobRunTriggerFailed, match="Not found!"):
             await test_trigger_nonexistent_job()
 
+    async def test_trigger_nonexistent_run_id(self, respx_mock, dbt_cloud_credentials):
+        respx_mock.post(
+            "https://cloud.getdbt.com/api/v2/accounts/123456789/jobs/1/run/",
+            headers={"Authorization": "Bearer my_api_key"},
+        ).mock(return_value=Response(200, json={"data": {"project_id": 12345}}))
+
+        @flow
+        async def test_trigger_nonexistent_run_id_flow():
+            task_shorter_retry = trigger_dbt_cloud_job_run.with_options(
+                retries=1, retry_delay_seconds=1
+            )
+            await task_shorter_retry(
+                dbt_cloud_credentials=dbt_cloud_credentials,
+                job_id=1,
+            )
+
+        with pytest.raises(RuntimeError, match="Unable to determine run ID"):
+            await test_trigger_nonexistent_run_id_flow()
+
 
 class TestTriggerDbtCloudJobRunAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=True)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-dbt 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

Two problems fixed with this PR:
1. `id` is the wrong variable name
2. the logger.info raises an error if no run_id: `f"runs/{run_data['id']}/"` before the RuntimeError

<!-- Link to issue -->
Closes #

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-dbt/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
