### PR TITLE
Fix save load roundtrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The minimum version of `prefect-snowflake` - [#112](https://github.com/PrefectHQ/prefect-dbt/pull/112)
 - Decoupled fields of blocks from external Collections from the created dbt profile - [#112](https://github.com/PrefectHQ/prefect-dbt/pull/112)
+- `DbtCliProfile` is now accepts a `Union` of `SnowflakeTargetConfigs`, `BigQueryTargetConfigs`, and `PostgresTargetConfigs` for creation on UI - [#115](https://github.com/PrefectHQ/prefect-dbt/pull/115)
 
 ### Deprecated
 
@@ -19,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `DbtCliProfile` dropping subclasses of `TargetConfigs` upon loading - [#115](https://github.com/PrefectHQ/prefect-dbt/pull/115)
+- Preventing `TargetConfigs` from being dropped upon loading a `DbtCliProfile` - [#115](https://github.com/PrefectHQ/prefect-dbt/pull/115)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DbtCliProfile` dropping subclasses of `TargetConfigs` upon loading - [#115](https://github.com/PrefectHQ/prefect-dbt/pull/115)
+
 ### Security
 
 ## 0.2.7

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -99,7 +99,7 @@ class BaseTargetConfigs(DbtConfigs, abc.ABC):
     )
 
 
-class TargetConfigs(AbstractTargetConfigs):
+class TargetConfigs(BaseTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to the warehouse you're connecting to.

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -37,6 +37,7 @@ class DbtConfigs(Block, abc.ABC):
         Recursively populate configs_json.
         """
         for field_name, field in fields.items():
+            print(field_name)
             if model is not None:
                 # get actual value from model
                 field_value = getattr(model, field_name)

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -81,7 +81,7 @@ class DbtConfigs(Block, abc.ABC):
         return self._populate_configs_json({}, self.__fields__, model=self)
 
 
-class AbstractTargetConfigs(DbtConfigs, abc.ABC):
+class BaseTargetConfigs(DbtConfigs, abc.ABC):
     type: str = Field(default=..., description="The name of the database warehouse.")
     schema_: str = Field(
         alias="schema",

--- a/prefect_dbt/cli/configs/bigquery.py
+++ b/prefect_dbt/cli/configs/bigquery.py
@@ -11,7 +11,10 @@ except ImportError:
 from prefect.utilities.asyncutils import sync_compatible
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
+from prefect_dbt.cli.configs.base import (
+    AbstractTargetConfigs,
+    MissingExtrasRequireError,
+)
 
 try:
     from prefect_gcp.credentials import GcpCredentials
@@ -19,7 +22,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("BigQuery") from e
 
 
-class BigQueryTargetConfigs(TargetConfigs):
+class BigQueryTargetConfigs(AbstractTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to BigQuery.

--- a/prefect_dbt/cli/configs/bigquery.py
+++ b/prefect_dbt/cli/configs/bigquery.py
@@ -11,10 +11,7 @@ except ImportError:
 from prefect.utilities.asyncutils import sync_compatible
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import (
-    AbstractTargetConfigs,
-    MissingExtrasRequireError,
-)
+from prefect_dbt.cli.configs.base import BaseTargetConfigs, MissingExtrasRequireError
 
 try:
     from prefect_gcp.credentials import GcpCredentials
@@ -22,7 +19,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("BigQuery") from e
 
 
-class BigQueryTargetConfigs(AbstractTargetConfigs):
+class BigQueryTargetConfigs(BaseTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to BigQuery.

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -63,7 +63,7 @@ class PostgresTargetConfigs(TargetConfigs):
         default="postgres", description="The type of the target."
     )
     credentials: DatabaseCredentials = Field(
-        default_factory=DatabaseCredentials,
+        default_factory=...,
         description=(
             "The credentials to use to authenticate; if there are duplicate keys "
             "between credentials and TargetConfigs, e.g. schema, "

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -11,7 +11,7 @@ from pydantic import Field
 from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
 
 try:
-    from prefect_sqlalchemy.database import DatabaseCredentials
+    from prefect_sqlalchemy.credentials import DatabaseCredentials
 except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Postgres") from e
 

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -11,7 +11,7 @@ from pydantic import Field
 from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
 
 try:
-    from prefect_sqlalchemy.credentials import DatabaseCredentials
+    from prefect_sqlalchemy.database import DatabaseCredentials
 except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Postgres") from e
 

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -8,7 +8,10 @@ except ImportError:
 
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
+from prefect_dbt.cli.configs.base import (
+    AbstractTargetConfigs,
+    MissingExtrasRequireError,
+)
 
 try:
     from prefect_sqlalchemy.database import DatabaseCredentials
@@ -16,7 +19,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Postgres") from e
 
 
-class PostgresTargetConfigs(TargetConfigs):
+class PostgresTargetConfigs(AbstractTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to Postgres.
@@ -63,7 +66,7 @@ class PostgresTargetConfigs(TargetConfigs):
         default="postgres", description="The type of the target."
     )
     credentials: DatabaseCredentials = Field(
-        default_factory=...,
+        default=...,
         description=(
             "The credentials to use to authenticate; if there are duplicate keys "
             "between credentials and TargetConfigs, e.g. schema, "

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -8,10 +8,7 @@ except ImportError:
 
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import (
-    AbstractTargetConfigs,
-    MissingExtrasRequireError,
-)
+from prefect_dbt.cli.configs.base import BaseTargetConfigs, MissingExtrasRequireError
 
 try:
     from prefect_sqlalchemy.database import DatabaseCredentials
@@ -19,7 +16,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Postgres") from e
 
 
-class PostgresTargetConfigs(AbstractTargetConfigs):
+class PostgresTargetConfigs(BaseTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to Postgres.

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -8,7 +8,10 @@ except ImportError:
 
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import MissingExtrasRequireError, TargetConfigs
+from prefect_dbt.cli.configs.base import (
+    AbstractTargetConfigs,
+    MissingExtrasRequireError,
+)
 
 try:
     from prefect_snowflake.database import SnowflakeConnector
@@ -16,7 +19,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Snowflake") from e
 
 
-class SnowflakeTargetConfigs(TargetConfigs):
+class SnowflakeTargetConfigs(AbstractTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to Snowflake.
@@ -73,7 +76,7 @@ class SnowflakeTargetConfigs(TargetConfigs):
         description="The schema to use for the target configs.",
     )
     connector: SnowflakeConnector = Field(
-        default=None, description="The connector to use."
+        default=..., description="The connector to use."
     )
 
     def get_configs(self) -> Dict[str, Any]:

--- a/prefect_dbt/cli/configs/snowflake.py
+++ b/prefect_dbt/cli/configs/snowflake.py
@@ -8,10 +8,7 @@ except ImportError:
 
 from pydantic import Field
 
-from prefect_dbt.cli.configs.base import (
-    AbstractTargetConfigs,
-    MissingExtrasRequireError,
-)
+from prefect_dbt.cli.configs.base import BaseTargetConfigs, MissingExtrasRequireError
 
 try:
     from prefect_snowflake.database import SnowflakeConnector
@@ -19,7 +16,7 @@ except ModuleNotFoundError as e:
     raise MissingExtrasRequireError("Snowflake") from e
 
 
-class SnowflakeTargetConfigs(AbstractTargetConfigs):
+class SnowflakeTargetConfigs(BaseTargetConfigs):
     """
     Target configs contain credentials and
     settings, specific to Snowflake.

--- a/prefect_dbt/cli/credentials.py
+++ b/prefect_dbt/cli/credentials.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict, Optional, Union
 
 from prefect.blocks.core import Block
-from pydantic import Field, validator
+from pydantic import Field
 
 from prefect_dbt.cli.configs import GlobalConfigs, TargetConfigs
 
@@ -135,18 +135,6 @@ class DbtCliProfile(Block):
             "mismatch or a failing model."
         ),
     )
-
-    @validator("target_configs", pre=True)
-    def _serialize_target_configs_from_dict(
-        cls, value: Union[dict, TargetConfigs]
-    ) -> TargetConfigs:
-        """
-        Explicitly serialize a dict into TargetConfigs. Without this, pydantic tries to
-        serialize into the first Union type, which is SnowflakeTargetConfigs.
-        """
-        if isinstance(value, dict):
-            return TargetConfigs(**value)
-        return value
 
     def get_profile(self) -> Dict[str, Any]:
         """

--- a/tests/cli/configs/test_bigquery.py
+++ b/tests/cli/configs/test_bigquery.py
@@ -1,52 +1,8 @@
-import json
 from unittest.mock import MagicMock, seal
 
-import pytest
 from prefect_gcp.credentials import GcpCredentials
 
 from prefect_dbt.cli.configs import BigQueryTargetConfigs
-
-
-@pytest.fixture()
-def service_account_info_dict(monkeypatch):
-    monkeypatch.setattr(
-        "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
-        lambda *args, **kwargs: args[0],
-    )
-    _service_account_info = {
-        "project_id": "service_project",
-        "token_uri": "my-token-uri",
-        "client_email": "my-client-email",
-        "private_key": "my-private-key",
-    }
-    return _service_account_info
-
-
-@pytest.fixture()
-def service_account_file(monkeypatch, tmp_path, service_account_info_dict):
-    monkeypatch.setattr(
-        "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
-        lambda *args, **kwargs: args[0],
-    )
-    _service_account_file = tmp_path / "gcp.json"
-    with open(_service_account_file, "w") as f:
-        json.dump(service_account_info_dict, f)
-    return _service_account_file
-
-
-@pytest.fixture
-def google_auth(monkeypatch):
-    google_auth_mock = MagicMock(name="google_auth")
-    default_credentials_mock = MagicMock(
-        name="default_credentials",
-        quota_project_id="my_project",
-    )
-    google_auth_mock.default.side_effect = lambda *args, **kwargs: (
-        default_credentials_mock,
-        None,
-    )
-    monkeypatch.setattr("google.auth", google_auth_mock)
-    return google_auth_mock
 
 
 class TestBigQueryTargetConfigs:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -73,7 +73,7 @@ def test_trigger_dbt_cli_command_run_twice_overwrite(
             "outputs": {
                 "testing": {
                     "type": "custom",
-                    "schema": "schema",
+                    "schema": "my_schema",
                     "threads": 4,
                     "account": "fake",
                 }

--- a/tests/cli/test_credentials.py
+++ b/tests/cli/test_credentials.py
@@ -24,8 +24,8 @@ def test_dbt_cli_profile_init(configs_type):
 
 
 def test_dbt_cli_profile_init_validation_failed():
-    # 7 instead of 2 now because it tries to validate each of the Union types
-    with pytest.raises(ValidationError, match="7 validation errors for DbtCliProfile"):
+    # 6 instead of 2 now because it tries to validate each of the Union types
+    with pytest.raises(ValidationError, match="6 validation errors for DbtCliProfile"):
         DbtCliProfile(
             name="test_name", target="dev", target_configs={"extras": {"field": "abc"}}
         )
@@ -56,8 +56,8 @@ def test_dbt_cli_profile_get_profile():
 @pytest.mark.parametrize(
     "target_configs_request",
     [
-        # "snowflake_target_configs",
-        # "dict_target_configs",
+        "snowflake_target_configs",
+        "dict_target_configs",
         "class_target_configs",
     ],
 )
@@ -71,9 +71,4 @@ def test_dbt_cli_profile_save_load_roundtrip(target_configs_request, request):
     block_name = target_configs_request.replace("_", "-")
     dbt_cli_profile.save(block_name)
     dbt_cli_profile_loaded = DbtCliProfile.load(block_name)
-    print(dbt_cli_profile.target_configs.schema_, "11")
-    print(dbt_cli_profile.get_profile())
-    print(dbt_cli_profile_loaded.target_configs.schema, "22")
-    raise
-    print(dbt_cli_profile_loaded.get_profile())
-    # assert dbt_cli_profile_loaded.get_profile()
+    assert dbt_cli_profile_loaded.get_profile()

--- a/tests/cli/test_credentials.py
+++ b/tests/cli/test_credentials.py
@@ -49,3 +49,27 @@ def test_dbt_cli_profile_get_profile():
         },
     }
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "target_configs_name",
+    [
+        "snowflake_target_configs",
+        "bigquery_target_configs",
+        "postgres_target_configs",
+        "dict_target_configs",
+        "class_target_configs",
+    ],
+)
+def test_dbt_cli_profile_save_load_roundtrip(target_configs_name, request):
+    target_configs = request.getfixturevalue(target_configs_name)
+    dbt_cli_profile = DbtCliProfile(
+        name="my_name",
+        target="dev",
+        target_configs=target_configs,
+    )
+    block_name = target_configs_name.replace("_", "-")
+    dbt_cli_profile.save(block_name)
+    dbt_cli_profile_loaded = dbt_cli_profile.load(block_name)
+    assert dbt_cli_profile_loaded == dbt_cli_profile
+    assert dbt_cli_profile_loaded.get_profile() == dbt_cli_profile.get_profile()

--- a/tests/cli/test_credentials.py
+++ b/tests/cli/test_credentials.py
@@ -18,12 +18,14 @@ def test_dbt_cli_profile_init(configs_type):
         target_configs=target_configs,
         global_configs=global_configs,
     )
+    assert isinstance(dbt_cli_profile.target_configs, TargetConfigs)
     assert dbt_cli_profile.name == "test_name"
     assert dbt_cli_profile.target == "dev"
 
 
 def test_dbt_cli_profile_init_validation_failed():
-    with pytest.raises(ValidationError, match="2 validation errors for DbtCliProfile"):
+    # 7 instead of 2 now because it tries to validate each of the Union types
+    with pytest.raises(ValidationError, match="7 validation errors for DbtCliProfile"):
         DbtCliProfile(
             name="test_name", target="dev", target_configs={"extras": {"field": "abc"}}
         )
@@ -52,24 +54,26 @@ def test_dbt_cli_profile_get_profile():
 
 
 @pytest.mark.parametrize(
-    "target_configs_name",
+    "target_configs_request",
     [
-        "snowflake_target_configs",
-        "bigquery_target_configs",
-        "postgres_target_configs",
-        "dict_target_configs",
+        # "snowflake_target_configs",
+        # "dict_target_configs",
         "class_target_configs",
     ],
 )
-def test_dbt_cli_profile_save_load_roundtrip(target_configs_name, request):
-    target_configs = request.getfixturevalue(target_configs_name)
+def test_dbt_cli_profile_save_load_roundtrip(target_configs_request, request):
+    target_configs = request.getfixturevalue(target_configs_request)
     dbt_cli_profile = DbtCliProfile(
         name="my_name",
         target="dev",
         target_configs=target_configs,
     )
-    block_name = target_configs_name.replace("_", "-")
+    block_name = target_configs_request.replace("_", "-")
     dbt_cli_profile.save(block_name)
-    dbt_cli_profile_loaded = dbt_cli_profile.load(block_name)
-    assert dbt_cli_profile_loaded == dbt_cli_profile
-    assert dbt_cli_profile_loaded.get_profile() == dbt_cli_profile.get_profile()
+    dbt_cli_profile_loaded = DbtCliProfile.load(block_name)
+    print(dbt_cli_profile.target_configs.schema_, "11")
+    print(dbt_cli_profile.get_profile())
+    print(dbt_cli_profile_loaded.target_configs.schema, "22")
+    raise
+    print(dbt_cli_profile_loaded.get_profile())
+    # assert dbt_cli_profile_loaded.get_profile()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,15 @@ def reset_object_registry():
         yield
 
 
+@pytest.fixture(autouse=True)
+def google_auth_mock(monkeypatch):
+    """
+    Mocks out the google.auth module.
+    """
+    google_auth_default_mock = MagicMock()
+    monkeypatch.setattr("google.auth.default", google_auth_default_mock)
+
+
 @pytest.fixture
 def dbt_cli_profile():
     target_configs = TargetConfigs(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def reset_object_registry():
 def dbt_cli_profile():
     target_configs = TargetConfigs(
         type="snowflake",
-        schema="schema",
+        schema="my_schema",
         threads=4,
         extras=dict(
             account="account",
@@ -89,7 +89,7 @@ def dbt_cli_profile():
 @pytest.fixture
 def dbt_cli_profile_bare():
     target_configs = TargetConfigs(
-        type="custom", schema="schema", extras={"account": "fake"}
+        type="custom", schema="my_schema", extras={"account": "fake"}
     )
     return DbtCliProfile(
         name="prefecto",
@@ -168,7 +168,7 @@ def postgres_target_configs():
         host="host",
         port=8080,
     )
-    target_configs = PostgresTargetConfigs(schema="schema", credentials=credentials)
+    target_configs = PostgresTargetConfigs(schema="my_schema", credentials=credentials)
     return target_configs
 
 
@@ -181,24 +181,24 @@ def sqlalchemy_target_configs():
             password="prefect_password",
         )
     )
-    target_configs = PostgresTargetConfigs(schema="schema", credentials=credentials)
+    target_configs = PostgresTargetConfigs(schema="my_schema", credentials=credentials)
     return target_configs
 
 
 @pytest.fixture
 def bigquery_target_configs(service_account_info_dict):
     credentials = GcpCredentials(service_account_info=service_account_info_dict)
-    target_configs = BigQueryTargetConfigs(credentials=credentials, schema="schema")
+    target_configs = BigQueryTargetConfigs(credentials=credentials, schema="my_schema")
     return target_configs
 
 
 @pytest.fixture
 def class_target_configs():
-    target_configs = TargetConfigs(type="type", schema="schema", threads=4)
+    target_configs = TargetConfigs(type="type", schema="my_schema", threads=4)
     return target_configs
 
 
 @pytest.fixture
 def dict_target_configs():
-    target_configs = dict(type="type", schema="schema", threads=4)
+    target_configs = dict(type="type", schema="my_schema", threads=4)
     return target_configs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,22 @@
+import json
+from unittest.mock import MagicMock
+
 import pytest
 from prefect.testing.utilities import prefect_test_harness
+from prefect_gcp import GcpCredentials
+from prefect_snowflake import SnowflakeConnector, SnowflakeCredentials
+from prefect_sqlalchemy import (
+    ConnectionComponents,
+    DatabaseCredentials,
+    SqlAlchemyConnector,
+    SyncDriver,
+)
 
+from prefect_dbt.cli.configs import (
+    BigQueryTargetConfigs,
+    PostgresTargetConfigs,
+    SnowflakeTargetConfigs,
+)
 from prefect_dbt.cli.configs.base import GlobalConfigs, TargetConfigs
 from prefect_dbt.cli.credentials import DbtCliProfile
 from prefect_dbt.cloud.credentials import DbtCloudCredentials
@@ -80,3 +96,109 @@ def dbt_cli_profile_bare():
         target="testing",
         target_configs=target_configs,
     )
+
+
+@pytest.fixture()
+def service_account_info_dict(monkeypatch):
+    monkeypatch.setattr(
+        "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
+        lambda *args, **kwargs: args[0],
+    )
+    _service_account_info = {
+        "project_id": "service_project",
+        "token_uri": "my-token-uri",
+        "client_email": "my-client-email",
+        "private_key": "my-private-key",
+    }
+    return _service_account_info
+
+
+@pytest.fixture()
+def service_account_file(monkeypatch, tmp_path, service_account_info_dict):
+    monkeypatch.setattr(
+        "google.auth.crypt._cryptography_rsa.serialization.load_pem_private_key",
+        lambda *args, **kwargs: args[0],
+    )
+    _service_account_file = tmp_path / "gcp.json"
+    with open(_service_account_file, "w") as f:
+        json.dump(service_account_info_dict, f)
+    return _service_account_file
+
+
+@pytest.fixture
+def google_auth(monkeypatch):
+    google_auth_mock = MagicMock(name="google_auth")
+    default_credentials_mock = MagicMock(
+        name="default_credentials",
+        quota_project_id="my_project",
+    )
+    google_auth_mock.default.side_effect = lambda *args, **kwargs: (
+        default_credentials_mock,
+        None,
+    )
+    monkeypatch.setattr("google.auth", google_auth_mock)
+    return google_auth_mock
+
+
+@pytest.fixture
+def snowflake_target_configs():
+    credentials = SnowflakeCredentials(
+        user="user",
+        password="password",
+        account="account.region.aws",
+        role="role",
+    )
+    connector = SnowflakeConnector(
+        schema="public",
+        database="database",
+        warehouse="warehouse",
+        credentials=credentials,
+    )
+    target_configs = SnowflakeTargetConfigs(connector=connector)
+    return target_configs
+
+
+@pytest.fixture
+def postgres_target_configs():
+    credentials = DatabaseCredentials(
+        driver=SyncDriver.POSTGRESQL_PSYCOPG2,
+        username="prefect",
+        password="prefect_password",
+        database="postgres",
+        host="host",
+        port=8080,
+    )
+    target_configs = PostgresTargetConfigs(schema="schema", credentials=credentials)
+    return target_configs
+
+
+def sqlalchemy_target_configs():
+    credentials = SqlAlchemyConnector(
+        connection_info=ConnectionComponents(
+            driver=SyncDriver.POSTGRESQL_PSYCOPG2,
+            database="postgres",
+            username="prefect",
+            password="prefect_password",
+        )
+    )
+    target_configs = PostgresTargetConfigs(schema="schema", credentials=credentials)
+    return target_configs
+
+
+@pytest.fixture
+def bigquery_target_configs(service_account_info_dict):
+    credentials = GcpCredentials(service_account_info=service_account_info_dict)
+    target_configs = BigQueryTargetConfigs(credentials=credentials, schema="schema")
+    return target_configs
+
+
+@pytest.fixture
+def class_target_configs():
+    target_configs = TargetConfigs(type="type", schema="schema", threads=4)
+    return target_configs
+
+
+@pytest.fixture
+def dict_target_configs():
+    target_configs = dict(type="type", schema="schema", threads=4)
+    return target_configs


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Upon loading `DbtCliProfile`, the original fields from the specialized TargetConfigs gets dropped. The following used to have a credentials field.
```
DbtCliProfile(name='bigbird', target='abc', target_configs=TargetConfigs(extras=None, type='bigquery', threads=20), global_configs=None)
Expected
```

Closes https://github.com/PrefectHQ/prefect-dbt/issues/114

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

![image](https://user-images.githubusercontent.com/15331990/215941199-21356509-644c-47f3-b45b-789a6a4a87c5.png)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-dbt/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
