### PR TITLE
Fix dumping paths upon writing profiles.yml by casting to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Preventing `TargetConfigs` from being dropped upon loading a `DbtCliProfile` - [#115](https://github.com/PrefectHQ/prefect-dbt/pull/115)
 - The input type of `GlobalConfigs.log_format` [#118](https://github.com/PrefectHQ/prefect-dbt/pull/118)
+- Properly casting `SnowflakeCredentials.private_key_path` to string before using `yaml.dump` - [#127](https://github.com/PrefectHQ/prefect-dbt/pull/127)
 
 ### Security
 

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -68,7 +68,7 @@ class DbtConfigs(Block, abc.ABC):
                     )
                 if isinstance(field_value, SecretField):
                     field_value = field_value.get_secret_value()
-                elif isinstance(field_value, PosixPath):
+                elif isinstance(field_value, Path):
                     field_value = str(field_value)
                 configs_json[field_name] = field_value
 

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -1,6 +1,7 @@
 """Module containing models for base configs"""
 
 import abc
+from pathlib import PosixPath
 from typing import Any, Dict, Optional
 
 from prefect.blocks.core import Block
@@ -67,6 +68,8 @@ class DbtConfigs(Block, abc.ABC):
                     )
                 if isinstance(field_value, SecretField):
                     field_value = field_value.get_secret_value()
+                elif isinstance(field_value, PosixPath):
+                    field_value = str(field_value)
                 configs_json[field_name] = field_value
 
         return configs_json

--- a/prefect_dbt/cli/configs/base.py
+++ b/prefect_dbt/cli/configs/base.py
@@ -1,7 +1,7 @@
 """Module containing models for base configs"""
 
 import abc
-from pathlib import PosixPath
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from prefect.blocks.core import Block

--- a/tests/cli/configs/test_base.py
+++ b/tests/cli/configs/test_base.py
@@ -1,3 +1,5 @@
+from pathlib import PosixPath
+
 import pytest
 
 from prefect_dbt.cli.configs.base import GlobalConfigs, TargetConfigs
@@ -8,12 +10,20 @@ def test_target_configs_get_configs():
         type="snowflake",
         schema="schema_input",
         threads=5,
-        extras={"extra_input": 1, "null_input": None},
+        extras={
+            "extra_input": 1,
+            "null_input": None,
+            "key_path": PosixPath("path/to/key"),
+        },
     )
     assert hasattr(target_configs, "_is_anonymous")
     # get_configs ignore private attrs
     assert target_configs.get_configs() == dict(
-        type="snowflake", schema="schema_input", threads=5, extra_input=1
+        type="snowflake",
+        schema="schema_input",
+        threads=5,
+        extra_input=1,
+        key_path="path/to/key",
     )
 
 

--- a/tests/cli/configs/test_base.py
+++ b/tests/cli/configs/test_base.py
@@ -1,4 +1,4 @@
-from pathlib import PosixPath
+from pathlib import Path
 
 import pytest
 
@@ -13,7 +13,7 @@ def test_target_configs_get_configs():
         extras={
             "extra_input": 1,
             "null_input": None,
-            "key_path": PosixPath("path/to/key"),
+            "key_path": Path("path/to/key"),
         },
     )
     assert hasattr(target_configs, "_is_anonymous")
@@ -23,7 +23,7 @@ def test_target_configs_get_configs():
         schema="schema_input",
         threads=5,
         extra_input=1,
-        key_path="path/to/key",
+        key_path=str(Path("path/to/key")),
     )
 
 

--- a/tests/cli/configs/test_snowflake.py
+++ b/tests/cli/configs/test_snowflake.py
@@ -46,7 +46,7 @@ def test_snowflake_target_configs_get_configs_private_key_path():
     credentials = SnowflakeCredentials(
         account="account",
         user="user",
-        private_key_path="path/to/key",
+        private_key_path=Path("path/to/key"),
     )
     snowflake_connector = SnowflakeConnector(
         schema="schema",
@@ -62,7 +62,7 @@ def test_snowflake_target_configs_get_configs_private_key_path():
     expected = dict(
         account="account",
         user="user",
-        private_key_path="path/to/key",
+        private_key_path=str(Path("path/to/key")),
         type="snowflake",
         schema="schema",
         database="database",

--- a/tests/cli/configs/test_snowflake.py
+++ b/tests/cli/configs/test_snowflake.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from prefect_snowflake.credentials import SnowflakeCredentials
 from prefect_snowflake.database import SnowflakeConnector
 from pydantic import SecretBytes, SecretStr

--- a/tests/cli/configs/test_snowflake.py
+++ b/tests/cli/configs/test_snowflake.py
@@ -40,3 +40,40 @@ def test_snowflake_target_configs_get_configs():
         )
         expected_v = expected[k]
         assert actual_v == expected_v
+
+
+def test_snowflake_target_configs_get_configs_private_key_path():
+    credentials = SnowflakeCredentials(
+        account="account",
+        user="user",
+        private_key_path="path/to/key",
+    )
+    snowflake_connector = SnowflakeConnector(
+        schema="schema",
+        database="database",
+        warehouse="warehouse",
+        credentials=credentials,
+    )
+    configs = SnowflakeTargetConfigs(
+        connector=snowflake_connector, extras={"retry_on_database_errors": True}
+    )
+
+    actual = configs.get_configs()
+    expected = dict(
+        account="account",
+        user="user",
+        private_key_path="path/to/key",
+        type="snowflake",
+        schema="schema",
+        database="database",
+        warehouse="warehouse",
+        authenticator="snowflake",
+        retry_on_database_errors=True,
+        threads=4,
+    )
+    for k, v in actual.items():
+        actual_v = (
+            v.get_secret_value() if isinstance(v, (SecretBytes, SecretStr)) else v
+        )
+        expected_v = expected[k]
+        assert actual_v == expected_v


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

The private_key_path is not written in the profiles file as expected:

```python
from prefect import flow
from prefect_snowflake.credentials import SnowflakeCredentials
from prefect_snowflake.database import SnowflakeConnector

from prefect_dbt.cli.credentials import DbtCliProfile
from prefect_dbt.cli.configs import SnowflakeTargetConfigs


@flow
def test_flow():
    credentials = SnowflakeCredentials(
        user="user",
        account="account.region.aws",
        private_key_path="my_path/to/key.p8",
        role="role",
    )
    credentials.save("sf-cred", overwrite=True)

    connector = SnowflakeConnector(
        schema="public",
        database="database",
        warehouse="warehouse",
        credentials=SnowflakeCredentials.load("sf-cred"),
    )
    connector.save("sf-conn", overwrite=True)

    target_configs = SnowflakeTargetConfigs(
        connector=SnowflakeConnector.load("sf-conn")
    )
    target_configs.save("dbt-targetconf", overwrite=True)

    dbt_cli_profile = DbtCliProfile(
        name="jaffle_shop",
        target="dev",
        target_configs=SnowflakeTargetConfigs.load("dbt-targetconf"),
    )
    dbt_cli_profile.save("example", overwrite=True)

    dbt_cli_profile = DbtCliProfile.load("example").get_profile()
```

```
config: {}
iris:
  outputs:
    dev:
      account: account.region.azure
      authenticator: snowflake
      database: dbname
      private_key_path: !!python/object/apply:pathlib.PosixPath
      - /
      - workspace
      - tmp
      - rsa_key.p8
      role: development
      schema: abc
      threads: 8
      type: snowflake
      user: username
      warehouse: wh
  target: dev
```

This PR casts the path to str.

Partially closes https://github.com/PrefectHQ/prefect-dbt/issues/125 (the other request is overriding schemas)

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![image](https://user-images.githubusercontent.com/15331990/219238891-0069833a-4e17-4308-beaf-3ae4338a57a9.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-dbt/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
