### PR TITLE
Convert string port to int port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Casting `PostgresTargetConfigs.port` as `int` from `str` so `dbt run` works - [#132](https://github.com/PrefectHQ/prefect-dbt/pull/132)
+
 ### Security
 
 ## 0.3.0

--- a/prefect_dbt/cli/configs/postgres.py
+++ b/prefect_dbt/cli/configs/postgres.py
@@ -112,4 +112,7 @@ class PostgresTargetConfigs(BaseTargetConfigs):
             # rename key to something dbt profile expects
             dbt_key = rename_keys.get(key) or key
             configs_json[dbt_key] = all_configs_json[key]
+        port = configs_json.get("port")
+        if port is not None:
+            configs_json["port"] = int(port)
         return configs_json

--- a/tests/cli/configs/test_postgres.py
+++ b/tests/cli/configs/test_postgres.py
@@ -28,7 +28,7 @@ def test_postgres_target_configs_get_configs():
         "user": "prefect",
         "password": "prefect_password",
         "host": "host",
-        "port": "8080",
+        "port": 8080,
     }
     for k, v in actual.items():
         actual_v = v.get_secret_value() if isinstance(v, SecretStr) else v

--- a/tests/cli/configs/test_postgres.py
+++ b/tests/cli/configs/test_postgres.py
@@ -62,7 +62,7 @@ def test_postgres_target_configs_get_configs_for_sqlalchemy_connector():
         "user": "prefect",
         "password": "prefect_password",
         "host": "host",
-        "port": "8080",
+        "port": 8080,
         "retries": 1,
     }
     for k, v in actual.items():

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -280,7 +280,7 @@ class TestDbtCoreOperation:
                 dbt_cli_profile=dbt_cli_profile,
             ) as op:
                 op.run()
-        except FileNotFoundError:
+        except (FileNotFoundError, TypeError):  # py37 raises TypeError
             pass  # we're mocking the tempfile; this is expected
 
         mock_write = mock_named_temporary_file.return_value.write

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -272,15 +272,18 @@ class TestDbtCoreOperation:
     ):
         mock_named_temporary_file = MagicMock(name="tempfile")
         monkeypatch.setattr("tempfile.NamedTemporaryFile", mock_named_temporary_file)
-        with DbtCoreOperation(
-            commands=["dbt debug"],
-            profiles_dir=tmp_path,
-            project_dir=tmp_path,
-            dbt_cli_profile=dbt_cli_profile,
-        ) as op:
-            op.run()
+        try:
+            with DbtCoreOperation(
+                commands=["dbt debug"],
+                profiles_dir=tmp_path,
+                project_dir=tmp_path,
+                dbt_cli_profile=dbt_cli_profile,
+            ) as op:
+                op.run()
+        except FileNotFoundError:
+            pass  # we're mocking the tempfile; this is expected
 
-        mock_write = mock_named_temporary_file.return_value.__enter__.return_value.write
+        mock_write = mock_named_temporary_file.return_value.write
         assert (
             mock_write.call_args_list[0][0][0]
             == f"dbt debug --profiles-dir {tmp_path} --project-dir {tmp_path}".encode()


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

User reports "Version 0.3.0 creates an invalid dbt profile for postgres. Port value in the target config is set as string which fails dbt cli run. Profile is correct with version 0.2.7."

Closes https://github.com/PrefectHQ/prefect-dbt/issues/131

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-dbt/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-dbt/blob/main/CHANGELOG.md)
